### PR TITLE
Fix error in POMs when building geowave

### DIFF
--- a/mrgeo-dataprovider/mrgeo-dataprovider-geowave/pom.xml
+++ b/mrgeo-dataprovider/mrgeo-dataprovider-geowave/pom.xml
@@ -83,10 +83,12 @@
       <groupId>mil.nga.giat</groupId>
       <artifactId>geowave-vector</artifactId>
     </dependency>
+    <!--
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-main</artifactId>
     </dependency>
+    -->
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-cql</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2009-2015 DigitalGlobe, Inc.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and limitations under the License.
-  -->
+     ~ Copyright 2009-2015 DigitalGlobe, Inc.
+     ~
+     ~ Licensed under the Apache License, Version 2.0 (the "License");
+     ~ you may not use this file except in compliance with the License.
+     ~ You may obtain a copy of the License at
+     ~
+     ~ http://www.apache.org/licenses/LICENSE-2.0
+     ~
+     ~ Unless required by applicable law or agreed to in writing, software
+     ~ distributed under the License is distributed on an "AS IS" BASIS,
+     ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     ~ See the License for the specific language governing permissions and limitations under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.mrgeo</groupId>
@@ -2414,6 +2414,10 @@
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -2666,17 +2670,17 @@
         <artifactId>gdal</artifactId>
         <version>${gdal.version}</version>
       </dependency>
-      <!--
+      <!-- This geotools dependency is used in mrgeo-dataprovider-geowave -->
       <dependency>
         <groupId>org.geotools</groupId>
         <artifactId>gt-cql</artifactId>
         <version>${geotools.version}</version>
       </dependency>
+      <!-- gt-cql includes gt-main & gt-wps, but we need to exclude common-logging from these -->
       <dependency>
         <groupId>org.geotools</groupId>
         <artifactId>gt-main</artifactId>
         <version>${geotools.version}</version>
-        <scope>runtime</scope>
         <exclusions>
           <exclusion>
             <groupId>commons-logging</groupId>
@@ -2686,129 +2690,141 @@
       </dependency>
       <dependency>
         <groupId>org.geotools</groupId>
-        <artifactId>gt-api</artifactId>
+        <artifactId>gt-wps</artifactId>
         <version>${geotools.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
-      <dependency>
-        <groupId>org.geotools</groupId>
-        <artifactId>gt-imagemosaic</artifactId>
-        <version>${geotools.version}</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.geotools</groupId>
-        <artifactId>gt-jdbc</artifactId>
-        <version>${geotools.version}</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.geotools</groupId>
-        <artifactId>gt-opengis</artifactId>
-        <version>${geotools.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.geotools</groupId>
-        <artifactId>gt-property</artifactId>
-        <version>${geotools.version}</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.geotools</groupId>
-        <artifactId>gt-process</artifactId>
-        <version>${geotools.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.geotools</groupId>
-        <artifactId>gt-process-raster</artifactId>
-        <version>${geotools.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.geotools</groupId>
-        <artifactId>gt-image</artifactId>
-        <version>${geotools.version}</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.geotools</groupId>
-        <artifactId>gt-geotiff</artifactId>
-        <version>${geotools.version}</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.geotools</groupId>
-        <artifactId>gt-coverage</artifactId>
-        <version>${geotools.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.geotools</groupId>
-        <artifactId>gt-geometry</artifactId>
-        <version>${geotools.version}</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.geotools</groupId>
-        <artifactId>gt-shapefile</artifactId>
-        <version>${geotools.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.geotools</groupId>
-        <artifactId>gt-transform</artifactId>
-        <version>${geotools.version}</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.geotools</groupId>
-        <artifactId>gt-xml</artifactId>
-        <version>${geotools.version}</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.geotools.xsd</groupId>
-        <artifactId>gt-xsd-kml</artifactId>
-        <version>${geotools.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.geotools</groupId>
-        <artifactId>gt-process-feature</artifactId>
-        <version>${geotools.version}</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.geotools</groupId>
-        <artifactId>gt-svg</artifactId>
-        <version>${geotools.version}</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.geotools</groupId>
-        <artifactId>gt-wfs-ng</artifactId>
-        <version>${geotools.version}</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.geotools</groupId>
-        <artifactId>gt-wms</artifactId>
-        <version>${geotools.version}</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.geotools</groupId>
-        <artifactId>gt-wms</artifactId>
-        <version>${geotools.version}</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.geotools.xsd</groupId>
-        <artifactId>gt-xsd-sld</artifactId>
-        <version>${geotools.version}</version>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.geotools.ogc</groupId>
-        <artifactId>net.opengis.wfs</artifactId>
-        <version>${geotools.version}</version>
-        <scope>runtime</scope>
-      </dependency>
+      <!--
+           <dependency>
+           <groupId>org.geotools</groupId>
+           <artifactId>gt-api</artifactId>
+           <version>${geotools.version}</version>
+           </dependency>
+           <dependency>
+           <groupId>org.geotools</groupId>
+           <artifactId>gt-imagemosaic</artifactId>
+           <version>${geotools.version}</version>
+           <scope>runtime</scope>
+           </dependency>
+           <dependency>
+           <groupId>org.geotools</groupId>
+           <artifactId>gt-jdbc</artifactId>
+           <version>${geotools.version}</version>
+           <scope>runtime</scope>
+           </dependency>
+           <dependency>
+           <groupId>org.geotools</groupId>
+           <artifactId>gt-opengis</artifactId>
+           <version>${geotools.version}</version>
+           </dependency>
+           <dependency>
+           <groupId>org.geotools</groupId>
+           <artifactId>gt-property</artifactId>
+           <version>${geotools.version}</version>
+           <scope>runtime</scope>
+           </dependency>
+           <dependency>
+           <groupId>org.geotools</groupId>
+           <artifactId>gt-process</artifactId>
+           <version>${geotools.version}</version>
+           </dependency>
+           <dependency>
+           <groupId>org.geotools</groupId>
+           <artifactId>gt-process-raster</artifactId>
+           <version>${geotools.version}</version>
+           </dependency>
+           <dependency>
+           <groupId>org.geotools</groupId>
+           <artifactId>gt-image</artifactId>
+           <version>${geotools.version}</version>
+           <scope>runtime</scope>
+           </dependency>
+           <dependency>
+           <groupId>org.geotools</groupId>
+           <artifactId>gt-geotiff</artifactId>
+           <version>${geotools.version}</version>
+           <scope>runtime</scope>
+           </dependency>
+           <dependency>
+           <groupId>org.geotools</groupId>
+           <artifactId>gt-coverage</artifactId>
+           <version>${geotools.version}</version>
+           </dependency>
+           <dependency>
+           <groupId>org.geotools</groupId>
+           <artifactId>gt-geometry</artifactId>
+           <version>${geotools.version}</version>
+           <scope>runtime</scope>
+           </dependency>
+           <dependency>
+           <groupId>org.geotools</groupId>
+           <artifactId>gt-shapefile</artifactId>
+           <version>${geotools.version}</version>
+           </dependency>
+           <dependency>
+           <groupId>org.geotools</groupId>
+           <artifactId>gt-transform</artifactId>
+           <version>${geotools.version}</version>
+           <scope>runtime</scope>
+           </dependency>
+           <dependency>
+           <groupId>org.geotools</groupId>
+           <artifactId>gt-xml</artifactId>
+           <version>${geotools.version}</version>
+           <scope>runtime</scope>
+           </dependency>
+           <dependency>
+           <groupId>org.geotools.xsd</groupId>
+           <artifactId>gt-xsd-kml</artifactId>
+           <version>${geotools.version}</version>
+           </dependency>
+           <dependency>
+           <groupId>org.geotools</groupId>
+           <artifactId>gt-process-feature</artifactId>
+           <version>${geotools.version}</version>
+           <scope>runtime</scope>
+           </dependency>
+           <dependency>
+           <groupId>org.geotools</groupId>
+           <artifactId>gt-svg</artifactId>
+           <version>${geotools.version}</version>
+           <scope>runtime</scope>
+           </dependency>
+           <dependency>
+           <groupId>org.geotools</groupId>
+           <artifactId>gt-wfs-ng</artifactId>
+           <version>${geotools.version}</version>
+           <scope>runtime</scope>
+           </dependency>
+           <dependency>
+           <groupId>org.geotools</groupId>
+           <artifactId>gt-wms</artifactId>
+           <version>${geotools.version}</version>
+           <scope>runtime</scope>
+           </dependency>
+           <dependency>
+           <groupId>org.geotools</groupId>
+           <artifactId>gt-wms</artifactId>
+           <version>${geotools.version}</version>
+           <scope>runtime</scope>
+           </dependency>
+           <dependency>
+           <groupId>org.geotools.xsd</groupId>
+           <artifactId>gt-xsd-sld</artifactId>
+           <version>${geotools.version}</version>
+           <scope>runtime</scope>
+           </dependency>
+           <dependency>
+           <groupId>org.geotools.ogc</groupId>
+           <artifactId>net.opengis.wfs</artifactId>
+           <version>${geotools.version}</version>
+           <scope>runtime</scope>
+           </dependency>
       -->
       <dependency>
         <groupId>org.geotools</groupId>
@@ -2827,7 +2843,6 @@
         <version>${geotools.version}</version>
         <scope>runtime</scope>
       </dependency>
-
       <dependency>
         <groupId>geotiff</groupId>
         <artifactId>geotiff-jai</artifactId>
@@ -2953,6 +2968,12 @@
         <groupId>org.springframework</groupId>
         <artifactId>spring-core</artifactId>
         <version>${spring.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
@@ -3153,6 +3174,10 @@
           <exclusion>
             <groupId>javax.servlet</groupId>
             <artifactId>servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
We weren't including the needed geotools files when building geowave.  Also excluded commons-logging from geowave, which crept back in sometime.