### PR TITLE
When building a pyramid, generate splits when running locally

### DIFF
--- a/mrgeo-core/src/main/java/org/mrgeo/data/image/MrsImageOutputFormatProvider.java
+++ b/mrgeo-core/src/main/java/org/mrgeo/data/image/MrsImageOutputFormatProvider.java
@@ -99,9 +99,9 @@ public abstract class MrsImageOutputFormatProvider implements ProtectionLevelVal
   /**
    * Perform any processing required after the map/reduce has completed.
    *
-   * @param job
+   * @param conf
    */
-  public abstract void teardown(final Job job) throws DataProviderException;
+  public abstract void teardown(final Configuration conf) throws DataProviderException;
 
   /**
    * Perform any processing required after a Spark job has completed.

--- a/mrgeo-core/src/main/java/org/mrgeo/hdfs/output/image/HdfsMrsPyramidOutputFormatProvider.java
+++ b/mrgeo-core/src/main/java/org/mrgeo/hdfs/output/image/HdfsMrsPyramidOutputFormatProvider.java
@@ -121,18 +121,7 @@ private void setup(final Configuration conf, Job job) throws IOException
 }
 
 @Override
-public void teardown(final Job job) throws DataProviderException
-{
-  performTeardown(job.getConfiguration());
-}
-
-@Override
-public void teardownForSpark(final Configuration conf) throws DataProviderException
-{
-  // nothing to do
-}
-
-private void performTeardown(final Configuration conf) throws DataProviderException
+public void teardown(final Configuration conf) throws DataProviderException
 {
   try
   {
@@ -153,6 +142,12 @@ private void performTeardown(final Configuration conf) throws DataProviderExcept
   {
     throw new DataProviderException("Error in teardown", e);
   }
+}
+
+@Override
+public void teardownForSpark(final Configuration conf) throws DataProviderException
+{
+  // nothing to do
 }
 
 @Override

--- a/mrgeo-dataprovider/mrgeo-dataprovider-accumulo/src/main/java/org/mrgeo/data/accumulo/output/image/AccumuloMrsPyramidOutputFormatProvider.java
+++ b/mrgeo-dataprovider/mrgeo-dataprovider-accumulo/src/main/java/org/mrgeo/data/accumulo/output/image/AccumuloMrsPyramidOutputFormatProvider.java
@@ -410,9 +410,9 @@ public class AccumuloMrsPyramidOutputFormatProvider extends MrsImageOutputFormat
 
 
   @Override
-  public void teardown(Job job) throws DataProviderException
+  public void teardown(Configuration conf) throws DataProviderException
   {
-    performTeardown(job.getConfiguration());
+    performTeardown(conf);
   }
 
   @Override

--- a/mrgeo-mapalgebra/mrgeo-mapalgebra-integrationtests/src/test/java/org/mrgeo/mapalgebra/BuildPyramidMapOpIntegrationTest.java
+++ b/mrgeo-mapalgebra/mrgeo-mapalgebra-integrationtests/src/test/java/org/mrgeo/mapalgebra/BuildPyramidMapOpIntegrationTest.java
@@ -96,6 +96,11 @@ public class BuildPyramidMapOpIntegrationTest extends LocalRunnerTest
 
     for (int level = metadata.getMaxZoomLevel(); level >= 1; level--)
     {
+      // Check for splits before opening the image because that will create
+      // the splits if it is missing
+      Path splitsPath = new Path(smallElevationPath, level + "/splits");
+      Assert.assertTrue("Missing splits file in " + splitsPath.toString(),
+                        HadoopFileUtils.exists(conf, splitsPath));
       MrsImage image = pyramid.getImage(level);
       Assert.assertNotNull("MrsImage image missing for level " + level, image);
       image.close();
@@ -125,6 +130,11 @@ public class BuildPyramidMapOpIntegrationTest extends LocalRunnerTest
 
     for (int level = metadata.getMaxZoomLevel(); level >= 1; level--)
     {
+      // Check for splits before opening the image because that will create
+      // the splits if it is missing
+      Path splitsPath = new Path(smallElevationNoPyramidsPath, level + "/splits");
+      Assert.assertTrue("Missing splits file in " + splitsPath.toString(),
+                        HadoopFileUtils.exists(conf, splitsPath));
       MrsImage image = pyramid.getImage(level);
       Assert.assertNotNull("MrsImage image missing for level " + level, image);
       image.close();
@@ -156,6 +166,11 @@ public class BuildPyramidMapOpIntegrationTest extends LocalRunnerTest
 
     for (int level = metadata.getMaxZoomLevel(); level >= 1; level--)
     {
+      // Check for splits before opening the image because that will create
+      // the splits if it is missing
+      Path splitsPath = new Path(smallElevationNoPyramidsPath, level + "/splits");
+      Assert.assertTrue("Missing splits file in " + splitsPath.toString(),
+                        HadoopFileUtils.exists(conf, splitsPath));
       MrsImage image = pyramid.getImage(level);
       Assert.assertNotNull("MrsImage image missing for level " + level, image);
       image.close();
@@ -185,6 +200,11 @@ public class BuildPyramidMapOpIntegrationTest extends LocalRunnerTest
 
     for (int level = metadata.getMaxZoomLevel(); level >= 1; level--)
     {
+      // Check for splits before opening the image because that will create
+      // the splits if it is missing
+      Path splitsPath = new Path(smallElevationNoPyramidsPath, level + "/splits");
+      Assert.assertTrue("Missing splits file in " + splitsPath.toString(),
+                        HadoopFileUtils.exists(conf, splitsPath));
       MrsImage image = pyramid.getImage(level);
       Assert.assertNotNull("MrsImage image missing for level " + level, image);
       image.close();
@@ -214,6 +234,11 @@ public class BuildPyramidMapOpIntegrationTest extends LocalRunnerTest
 
     for (int level = metadata.getMaxZoomLevel(); level >= 1; level--)
     {
+      // Check for splits before opening the image because that will create
+      // the splits if it is missing
+      Path splitsPath = new Path(smallElevationNoPyramidsPath, level + "/splits");
+      Assert.assertTrue("Missing splits file in " + splitsPath.toString(),
+                        HadoopFileUtils.exists(conf, splitsPath));
       MrsImage image = pyramid.getImage(level);
       Assert.assertNotNull("MrsImage image missing for level " + level, image);
       image.close();
@@ -243,6 +268,11 @@ public class BuildPyramidMapOpIntegrationTest extends LocalRunnerTest
 
     for (int level = metadata.getMaxZoomLevel(); level >= 1; level--)
     {
+      // Check for splits before opening the image because that will create
+      // the splits if it is missing
+      Path splitsPath = new Path(smallElevationNoPyramidsPath, level + "/splits");
+      Assert.assertTrue("Missing splits file in " + splitsPath.toString(),
+                        HadoopFileUtils.exists(conf, splitsPath));
       MrsImage image = pyramid.getImage(level);
       Assert.assertNotNull("MrsImage image missing for level " + level, image);
       image.close();
@@ -272,6 +302,11 @@ public class BuildPyramidMapOpIntegrationTest extends LocalRunnerTest
 
     for (int level = metadata.getMaxZoomLevel(); level >= 1; level--)
     {
+      // Check for splits before opening the image because that will create
+      // the splits if it is missing
+      Path splitsPath = new Path(smallElevationNoPyramidsPath, level + "/splits");
+      Assert.assertTrue("Missing splits file in " + splitsPath.toString(),
+                        HadoopFileUtils.exists(conf, splitsPath));
       MrsImage image = pyramid.getImage(level);
       Assert.assertNotNull("MrsImage image missing for level " + level, image);
       image.close();
@@ -301,6 +336,11 @@ public class BuildPyramidMapOpIntegrationTest extends LocalRunnerTest
 
     for (int level = metadata.getMaxZoomLevel(); level >= 1; level--)
     {
+      // Check for splits before opening the image because that will create
+      // the splits if it is missing
+      Path splitsPath = new Path(smallElevationNoPyramidsPath, level + "/splits");
+      Assert.assertTrue("Missing splits file in " + splitsPath.toString(),
+                        HadoopFileUtils.exists(conf, splitsPath));
       MrsImage image = pyramid.getImage(level);
       Assert.assertNotNull("MrsImage image missing for level " + level, image);
       image.close();
@@ -330,6 +370,11 @@ public class BuildPyramidMapOpIntegrationTest extends LocalRunnerTest
 
     for (int level = metadata.getMaxZoomLevel(); level >= 1; level--)
     {
+      // Check for splits before opening the image because that will create
+      // the splits if it is missing
+      Path splitsPath = new Path(smallElevationNoPyramidsPath, level + "/splits");
+      Assert.assertTrue("Missing splits file in " + splitsPath.toString(),
+                        HadoopFileUtils.exists(conf, splitsPath));
       MrsImage image = pyramid.getImage(level);
       Assert.assertNotNull("MrsImage image missing for level " + level, image);
       image.close();


### PR DESCRIPTION
- closes #187
- we always want a splits file for all levels of a pyramid but when
  build pyramid switches to running locally, it was not generating splits