### PR TITLE
Unit Tests for HdfsMrsPyramidRecordReader

### DIFF
--- a/mrgeo-core/src/test/java/org/mrgeo/hdfs/input/image/HdfsMrsPyramidRecordReaderTest.java
+++ b/mrgeo-core/src/test/java/org/mrgeo/hdfs/input/image/HdfsMrsPyramidRecordReaderTest.java
@@ -1,0 +1,149 @@
+package org.mrgeo.hdfs.input.image;
+
+import junit.framework.Assert;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.SequenceFile;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mrgeo.data.raster.RasterWritable;
+import org.mrgeo.data.tile.TileIdWritable;
+import org.mrgeo.hdfs.utils.*;
+import org.mrgeo.junit.UnitTest;
+import org.mrgeo.mapreduce.splitters.TiledInputSplit;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Created by ericwood on 6/10/16.
+ */
+public class HdfsMrsPyramidRecordReaderTest {
+
+
+
+    private TaskAttemptContext mockContext;
+    private SequenceFile.Reader mockReader;
+    private Configuration mockConfig;
+    private TiledInputSplit mockTiledInputSplit;
+    private HdfsMrsPyramidRecordReader subject;
+    private TileIdWritable mockTileId;
+    private RasterWritable mockRaster;
+    private FileSplit mockFileSplit;
+    private Path mockPath;
+    private TileIdWritable[] tileIds = {new TileIdWritable(1L), new TileIdWritable(2L), new TileIdWritable(3L)};
+    private RasterWritable[] rasters = {new RasterWritable("AB".getBytes()),
+                                        new RasterWritable("CD".getBytes()),
+                                        new RasterWritable("EF".getBytes())};
+
+
+    @Before
+    public void setUp() throws Exception {
+        // Create Mocks
+        mockContext = new TaskAttemptContextBuilder().configuration(
+                new ConfigurationBuilder().build()
+        ).build();
+
+        mockTiledInputSplit = new TiledInputSplitBuilder().wrappedSplit(
+                new FileSplitBuilder().path(
+                        new PathBuilder().fileSystem(
+                                new FileSystemBuilder().build())
+                        .build())
+                .build())
+        .build();
+
+        mockReader = new SequenceFileReaderBuilder()
+                .keyClass(TileIdWritable.class)
+                .valueClass(RasterWritable.class)
+                .keys(tileIds)
+                .values(rasters)
+        .build();
+
+//        mockTiledInputSplit = mock(TiledInputSplit.class);
+//        mockContext = mock(TaskAttemptContext.class);
+//        mockConfig = mock(Configuration.class);
+//        mockTileId = mock(TileIdWritable.class);
+//        mockRaster = mock(RasterWritable.class);
+//        mockFileSplit = mock(FileSplit.class);
+//        mockPath = mock(Path.class);
+//        mockFileSystem = mock(FileSystem.class);
+
+        // Instance under test
+        subject = new HdfsMrsPyramidRecordReader(new HdfsMrsPyramidRecordReader.ReaderFactory() {
+            public SequenceFile.Reader createReader(FileSystem fs, Path path, Configuration config) {
+                return mockReader;
+            }
+        });
+
+        subject.initialize(mockTiledInputSplit, mockContext);
+
+    }
+
+    private void setupTiledInputSplit(long startTileId, long endTileId) {
+        when(mockTiledInputSplit.getStartTileId()).thenReturn(startTileId);
+        when(mockTiledInputSplit.getEndTileId()).thenReturn(endTileId);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+
+    }
+
+    @Test
+    @Category(UnitTest.class)
+    public void getProgress() throws Exception {
+
+    }
+
+    @Test
+    @Category(UnitTest.class)
+    public void close() throws Exception {
+
+    }
+
+    @Test
+    @Category(UnitTest.class)
+    public void testInitializeWithNonTiledInputSplit() throws Exception {
+        InputSplit mockSplit = mock(InputSplit.class);
+        try {
+            subject.initialize(mockSplit, mockContext);
+            Assert.fail("initialize did not throw an exception if the input split was not a TiledInputSplit");
+        }
+        catch (IOException e) {
+            // Passed so do nothing
+        }
+    }
+
+
+
+//    @Test
+//    @Category(UnitTest.class)
+//    public void testInitialize() throws Exception {
+//        subject.initialize(mockTiledInputSplit, mockContext);
+//
+//        // verify Key and Value
+//
+//
+//    }
+
+    @Test
+    @Category(UnitTest.class)
+    public void testNextKeyValue() throws Exception {
+
+        for (int i = 0; i < tileIds.length; i++) {
+            Assert.assertTrue("more key values exist", subject.nextKeyValue());
+            Assert.assertEquals(subject.getCurrentKey(), tileIds[i]);
+            Assert.assertEquals(subject.getCurrentValue(), rasters[i]);
+        }
+        Assert.assertFalse("no more key values exist", subject.nextKeyValue());
+    }
+
+}

--- a/mrgeo-core/src/test/java/org/mrgeo/hdfs/utils/ConfigurationBuilder.java
+++ b/mrgeo-core/src/test/java/org/mrgeo/hdfs/utils/ConfigurationBuilder.java
@@ -1,0 +1,21 @@
+package org.mrgeo.hdfs.utils;
+
+import org.apache.hadoop.conf.Configuration;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Created by ericwood on 6/10/16.
+ */
+public class ConfigurationBuilder {
+
+    private final Configuration configuration;
+
+    public ConfigurationBuilder() {
+        this.configuration = mock(Configuration.class);
+    }
+
+    public Configuration build() {
+        return configuration;
+    }
+}

--- a/mrgeo-core/src/test/java/org/mrgeo/hdfs/utils/FileSplitBuilder.java
+++ b/mrgeo-core/src/test/java/org/mrgeo/hdfs/utils/FileSplitBuilder.java
@@ -1,0 +1,32 @@
+package org.mrgeo.hdfs.utils;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by ericwood on 6/13/16.
+ */
+public class FileSplitBuilder {
+    private FileSplit fileSplit;
+    private Path path;
+
+    public FileSplitBuilder() {
+        this.fileSplit = mock(FileSplit.class);
+    }
+
+    public FileSplitBuilder path(Path path) {
+        this.path = path;
+
+        return this;
+    }
+
+    public FileSplit build() {
+        when(fileSplit.getPath()).thenReturn(path);
+
+        return fileSplit;
+    }
+}

--- a/mrgeo-core/src/test/java/org/mrgeo/hdfs/utils/FileSystemBuilder.java
+++ b/mrgeo-core/src/test/java/org/mrgeo/hdfs/utils/FileSystemBuilder.java
@@ -1,0 +1,22 @@
+package org.mrgeo.hdfs.utils;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Created by ericwood on 6/10/16.
+ */
+public class FileSystemBuilder {
+
+    private final FileSystem fileSystem;
+
+    public FileSystemBuilder() {
+        this.fileSystem = mock(FileSystem.class);
+    }
+
+    public FileSystem build() {
+        return fileSystem;
+    }
+}

--- a/mrgeo-core/src/test/java/org/mrgeo/hdfs/utils/HdfsMrsImageReaderBuilder.java
+++ b/mrgeo-core/src/test/java/org/mrgeo/hdfs/utils/HdfsMrsImageReaderBuilder.java
@@ -1,0 +1,76 @@
+package org.mrgeo.hdfs.utils;
+
+import org.apache.hadoop.io.MapFile;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.mrgeo.data.tile.TileIdWritable;
+import org.mrgeo.hdfs.image.HdfsMrsImageReader;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by ericwood on 6/14/16.
+ */
+public class HdfsMrsImageReaderBuilder {
+    private HdfsMrsImageReader hdfsMrsImageReader;
+    private List<MapFile.Reader> mapFileReaders = new ArrayList<>();
+    private int maxPartitions;
+    private boolean canBeCached;
+    private int partitionIndex;
+
+    public HdfsMrsImageReaderBuilder() {
+        this.hdfsMrsImageReader = mock(HdfsMrsImageReader.class);
+    }
+
+    public HdfsMrsImageReaderBuilder mapFileReader(MapFile.Reader mapFileReader) {
+        // each call adds a new map file reader to the list
+        this.mapFileReaders.add(mapFileReader);
+
+        return this;
+    }
+
+    public HdfsMrsImageReaderBuilder maxPartitions(int maxPartitions) {
+        this.maxPartitions = maxPartitions;
+
+        return this;
+    }
+
+    public HdfsMrsImageReaderBuilder canBeCached(boolean canBeCached) {
+        this.canBeCached = canBeCached;
+
+        return this;
+    }
+
+    public HdfsMrsImageReaderBuilder partitionIndex(int partitionIndex) {
+        this.canBeCached = canBeCached;
+
+        return this;
+    }
+
+    public HdfsMrsImageReader build() throws IOException {
+        // Return the MapFile.Readers for the specified index
+        when(hdfsMrsImageReader.getReader(any(Integer.class))).thenAnswer(new Answer<MapFile.Reader>() {
+            @Override
+            public MapFile.Reader answer(InvocationOnMock invocationOnMock) throws Throwable {
+                int index = (Integer) invocationOnMock.getArguments()[0];
+                return mapFileReaders.get(index);
+            }
+        });
+
+        // Return the number of MapFile.Reader that have been configured
+        when(hdfsMrsImageReader.getMaxPartitions()).thenReturn(mapFileReaders.size());
+
+        // Always start at 0 for mock
+        when(hdfsMrsImageReader.getPartitionIndex(any(TileIdWritable.class))).thenReturn(0);
+
+        when(hdfsMrsImageReader.canBeCached()).thenReturn(canBeCached);
+
+        return hdfsMrsImageReader;
+    }
+}

--- a/mrgeo-core/src/test/java/org/mrgeo/hdfs/utils/KeyValueHelper.java
+++ b/mrgeo-core/src/test/java/org/mrgeo/hdfs/utils/KeyValueHelper.java
@@ -1,0 +1,117 @@
+package org.mrgeo.hdfs.utils;
+
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.WritableComparable;
+import org.apache.hadoop.io.WritableComparator;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.util.Arrays;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by ericwood on 6/13/16.
+ */
+public class KeyValueHelper {
+    private static final Logger logger = LoggerFactory.getLogger(KeyValueHelper.class);
+
+    private int index = 0;
+    private Class keyClass;
+    private Class valueClass;
+    private Writable[] keys;
+    private Writable[] values;
+
+    public KeyValueHelper() {
+
+    }
+
+    public KeyValueHelper keyClass(Class keyClass) {
+        this.keyClass = keyClass;
+
+        return this;
+    }
+
+    public KeyValueHelper valueClass(Class valueClass) {
+        this.valueClass = valueClass;
+
+        return this;
+    }
+
+    public Class getKeyClass() {
+        return keyClass;
+    }
+
+    public Class getValueClass() {
+        return valueClass;
+    }
+
+    public KeyValueHelper keys(Writable[] keys) {
+        this.keys = Arrays.copyOf(keys, keys.length);
+
+        return this;
+    }
+
+    public KeyValueHelper values(Writable[] values) {
+        this.values = Arrays.copyOf(values, values.length);
+
+        return this;
+    }
+
+    public boolean next(Writable key, Writable value) throws IOException {
+        if (index >= keys.length) return false;
+
+        // Get the key and value
+        copyData(keys[index], key);
+        copyData(values[index], value);
+        ++index;
+        return true;
+    }
+
+    public Writable getClosest(WritableComparable key, Writable value) throws IOException {
+
+        Writable foundKey = null;
+        Writable foundValue = null;
+        for (int i = 0; i < keys.length; i++) {
+            int result = ((WritableComparable)keys[i]).compareTo(key);
+            if (result == 0) {
+                foundKey = keys[i];
+                foundValue = values[i];
+                break;
+            }
+            else if (result > 0 && i > 0) {
+                foundKey = keys[i - 1];
+                foundValue = values[i - 1];
+                break;
+            }
+            else if (i == 0) {
+                return null;
+            }
+        }
+        if (foundKey != null) {
+            copyData(foundKey, (Writable)key);
+            copyData(foundValue, value);
+            return foundKey;
+        }
+        else {
+            return null;
+        }
+    }
+
+    private void copyData(Writable src, Writable tgt) throws IOException {
+        PipedInputStream in = new PipedInputStream();
+        PipedOutputStream out = new PipedOutputStream(in);
+        DataOutputStream dos = new DataOutputStream(out);
+        DataInputStream din = new DataInputStream(in);
+        src.write(dos);
+        tgt.readFields(din);
+    }
+
+
+
+}

--- a/mrgeo-core/src/test/java/org/mrgeo/hdfs/utils/MapFileReaderBuilder.java
+++ b/mrgeo-core/src/test/java/org/mrgeo/hdfs/utils/MapFileReaderBuilder.java
@@ -1,0 +1,85 @@
+package org.mrgeo.hdfs.utils;
+
+import org.apache.hadoop.io.MapFile;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.WritableComparable;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.util.Arrays;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by ericwood on 6/13/16.
+ */
+public class MapFileReaderBuilder {
+    private static final Logger logger = LoggerFactory.getLogger(MapFileReaderBuilder.class);
+
+    private MapFile.Reader mapFileReader;
+    private KeyValueHelper keyValueHelper;
+
+    public MapFileReaderBuilder() {
+        this.mapFileReader = mock(MapFile.Reader.class);
+        keyValueHelper = new KeyValueHelper();
+    }
+
+    public MapFileReaderBuilder keyClass(Class keyClass) {
+        keyValueHelper.keyClass(keyClass);
+
+        return this;
+    }
+
+    public MapFileReaderBuilder valueClass(Class valueClass) {
+        keyValueHelper.valueClass(valueClass);
+
+        return this;
+    }
+
+    public MapFileReaderBuilder keys(WritableComparable[] keys) {
+        keyValueHelper.keys(keys);
+
+        return this;
+    }
+
+    public MapFileReaderBuilder values(Writable[] values) {
+        keyValueHelper.values(values);
+
+        return this;
+    }
+
+    public MapFile.Reader build() throws IOException {
+        when(mapFileReader.getKeyClass()).thenReturn(keyValueHelper.getKeyClass());
+        when(mapFileReader.getValueClass()).thenReturn(keyValueHelper.getValueClass());
+
+        when(mapFileReader.next(any(WritableComparable.class), any(Writable.class))).thenAnswer(new Answer<Boolean>() {
+            @Override
+            public Boolean answer(InvocationOnMock invocationOnMock) throws Throwable {
+                // Get the key and value
+                Object[] args = invocationOnMock.getArguments();
+                Writable key = (Writable)args[0];
+                Writable value = (Writable)args[1];
+                return keyValueHelper.next(key, value);
+            }
+        });
+
+        when(mapFileReader.getClosest(any(WritableComparable.class), any(Writable.class))).thenAnswer(new Answer<Writable>() {
+            @Override
+            public Writable answer(InvocationOnMock invocationOnMock) throws Throwable {
+                // Get the key and value
+                Object[] args = invocationOnMock.getArguments();
+                WritableComparable key = (WritableComparable) args[0];
+                Writable value = (Writable)args[1];
+                return keyValueHelper.getClosest(key, value);
+            }
+        });
+
+        return mapFileReader;
+    }
+
+}

--- a/mrgeo-core/src/test/java/org/mrgeo/hdfs/utils/PathBuilder.java
+++ b/mrgeo-core/src/test/java/org/mrgeo/hdfs/utils/PathBuilder.java
@@ -1,0 +1,36 @@
+package org.mrgeo.hdfs.utils;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by ericwood on 6/10/16.
+ */
+public class PathBuilder {
+
+    private Path path;
+    private FileSystem fileSystem;
+
+    public PathBuilder() {
+        this.path = mock(Path.class);
+    }
+
+    public PathBuilder fileSystem(FileSystem fileSystem) {
+        this.fileSystem = fileSystem;
+
+        return this;
+    }
+
+    public Path build() throws IOException {
+        when(path.getFileSystem(any(Configuration.class))).thenReturn(fileSystem);
+
+        return path;
+    }
+}

--- a/mrgeo-core/src/test/java/org/mrgeo/hdfs/utils/SequenceFileReaderBuilder.java
+++ b/mrgeo-core/src/test/java/org/mrgeo/hdfs/utils/SequenceFileReaderBuilder.java
@@ -1,0 +1,96 @@
+package org.mrgeo.hdfs.utils;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.io.SequenceFile;
+import org.apache.hadoop.io.Writable;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.mrgeo.data.tile.TileIdWritable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.util.Arrays;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by ericwood on 6/13/16.
+ */
+public class SequenceFileReaderBuilder {
+    private static final Logger logger = LoggerFactory.getLogger(SequenceFileReaderBuilder.class);
+
+    private SequenceFile.Reader sequenceFileReader;
+    private Class keyClass;
+    private Class valueClass;
+    private Writable[] keys;
+    private Writable[] values;
+
+    public SequenceFileReaderBuilder() {
+        this.sequenceFileReader = mock(SequenceFile.Reader.class);
+    }
+
+    public SequenceFileReaderBuilder keyClass(Class keyClass) {
+        this.keyClass = keyClass;
+
+        return this;
+    }
+
+    public SequenceFileReaderBuilder valueClass(Class valueClass) {
+        this.valueClass = valueClass;
+
+        return this;
+    }
+
+    public SequenceFileReaderBuilder keys(Writable[] keys) {
+        this.keys = Arrays.copyOf(keys, keys.length);
+
+        return this;
+    }
+
+    public SequenceFileReaderBuilder values(Writable[] values) {
+        this.values = Arrays.copyOf(values, values.length);
+
+        return this;
+    }
+
+    public SequenceFile.Reader build() throws IOException {
+        when(sequenceFileReader.getKeyClass()).thenReturn(keyClass);
+        when(sequenceFileReader.getValueClass()).thenReturn(valueClass);
+
+        when(sequenceFileReader.next(any(Writable.class), any(Writable.class))).thenAnswer(new Answer<Boolean>() {
+            private int index = 0;
+            @Override
+            public Boolean answer(InvocationOnMock invocationOnMock) throws Throwable {
+                if (index >= keys.length) return false;
+
+                // Get the key and value
+                Object[] args = invocationOnMock.getArguments();
+                Writable key = (Writable)args[0];
+                Writable value = (Writable)args[1];
+                copyData(keys[index], key);
+                copyData(values[index], value);
+                logger.info("Read: key: " + keys[index] + " value: " + values[index] + " Wrote: key: " + key + " value: " + value);
+                ++index;
+                return true;
+            }
+
+            private void copyData(Writable src, Writable tgt) throws IOException {
+                PipedInputStream in = new PipedInputStream();
+                PipedOutputStream out = new PipedOutputStream(in);
+                DataOutputStream dos = new DataOutputStream(out);
+                DataInputStream din = new DataInputStream(in);
+                src.write(dos);
+                tgt.readFields(din);
+            }
+        });
+
+        return sequenceFileReader;
+    }
+
+}

--- a/mrgeo-core/src/test/java/org/mrgeo/hdfs/utils/TaskAttemptContextBuilder.java
+++ b/mrgeo-core/src/test/java/org/mrgeo/hdfs/utils/TaskAttemptContextBuilder.java
@@ -1,0 +1,31 @@
+package org.mrgeo.hdfs.utils;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Created by ericwood on 6/10/16.
+ */
+public class TaskAttemptContextBuilder {
+
+    private TaskAttemptContext taskAttemptContext;
+    private Configuration configuration;
+
+    public TaskAttemptContextBuilder() {
+        taskAttemptContext = mock(org.apache.hadoop.mapreduce.TaskAttemptContext.class);
+    }
+
+    public TaskAttemptContextBuilder configuration(Configuration configuration) {
+        this.configuration = configuration;
+
+        return this;
+    }
+
+    public TaskAttemptContext build() {
+        when(taskAttemptContext.getConfiguration()).thenReturn(configuration);
+
+        return taskAttemptContext;
+    }
+}

--- a/mrgeo-core/src/test/java/org/mrgeo/hdfs/utils/TiledInputSplitBuilder.java
+++ b/mrgeo-core/src/test/java/org/mrgeo/hdfs/utils/TiledInputSplitBuilder.java
@@ -1,0 +1,33 @@
+package org.mrgeo.hdfs.utils;
+
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.mrgeo.hdfs.tile.FileSplit;
+import org.mrgeo.mapreduce.splitters.TiledInputSplit;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Created by ericwood on 6/10/16.
+ */
+public class TiledInputSplitBuilder {
+    private TiledInputSplit tiledInputSplit;
+    private InputSplit wrappedSplit;
+
+    public TiledInputSplitBuilder() {
+        this.tiledInputSplit = mock(TiledInputSplit.class);
+    }
+
+    public TiledInputSplitBuilder wrappedSplit(InputSplit inputSplit) {
+        this.wrappedSplit = inputSplit;
+
+        return this;
+    }
+
+    public TiledInputSplit build() {
+        when(tiledInputSplit.getWrappedSplit()).thenReturn(wrappedSplit);
+
+        return tiledInputSplit;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -3270,6 +3270,12 @@
         <role>developer</role>
       </roles>
     </developer>
+    <developer>
+      <name>Eric Wood</name>
+      <roles>
+        <role>developer</role>
+      </roles>
+    </developer>
   </developers>
   <contributors>
     <contributor>


### PR DESCRIPTION
Added unit tests using Mockito to mock external components.  This testing suite covers all of the lines and branches that are meaningful to cover, and provides a foundation for mocking the HDFS library.

Signed-off-by: ericwood73 <ericwood73@gmail.com>