### PR TITLE
Fix reprojection problem in WCS and Raster REST endpoint

### DIFF
--- a/mrgeo-services/mrgeo-services-core/src/main/java/org/mrgeo/resources/mrspyramid/RasterResource.java
+++ b/mrgeo-services/mrgeo-services-core/src/main/java/org/mrgeo/resources/mrspyramid/RasterResource.java
@@ -191,9 +191,6 @@ public Response getImage(@PathParam("output") String imgName,
 
     Bounds bounds = new Bounds(minX, minY, maxX, maxY);
 
-    //Reproject bounds to EPSG:4326 if necessary
-    bounds = RequestUtils.reprojectBounds(bounds, srs);
-
     ColorScale cs = null;
     try
     {

--- a/mrgeo-services/mrgeo-services-wcs/src/main/java/org/mrgeo/resources/wcs/WcsGenerator.java
+++ b/mrgeo-services/mrgeo-services-wcs/src/main/java/org/mrgeo/resources/wcs/WcsGenerator.java
@@ -419,16 +419,6 @@ private Response getCoverage(MultivaluedMap<String, String> allParams,
     return writeError(Response.Status.BAD_REQUEST, e.getMessage());
   }
 
-  // Reproject bounds to EPSG:4326 if necessary
-  try
-  {
-    bounds = RequestUtils.reprojectBounds(bounds, crs);
-  }
-  catch (Exception e)
-  {
-    return writeError(Response.Status.BAD_REQUEST, e.getMessage());
-  }
-
   // Return the resulting image
   try
   {


### PR DESCRIPTION
- closes #370
- The bounds were being reprojected to WGS84 when they should not be.