### PR TITLE
Add parameter to map algebra ingest function for nodata override values

### DIFF
--- a/mrgeo-core/src/main/java/org/mrgeo/data/raster/RasterUtils.java
+++ b/mrgeo-core/src/main/java/org/mrgeo/data/raster/RasterUtils.java
@@ -184,7 +184,7 @@ public static RenderedImage getMostSpecificSource(RenderedImage[] sources)
 
 
 public static WritableRaster createCompatibleEmptyRaster(final Raster raster, final int width, final int height,
-    final Number[] nodata)
+    final double[] nodata)
 {
   final WritableRaster newraster = raster.createCompatibleWritableRaster(width, height);
   fillWithNodata(newraster, nodata);
@@ -216,7 +216,7 @@ public static WritableRaster createEmptyRaster(final int width, final int height
 }
 public static WritableRaster createEmptyRaster(final int width, final int height,
     final int bands, final int datatype,
-    final Number[] nodatas)
+    final double[] nodatas)
 {
   final WritableRaster raster = createEmptyRaster(width, height, bands, datatype);
   fillWithNodata(raster, nodatas);
@@ -306,7 +306,7 @@ public static void fillWithNodata(final WritableRaster raster, final double noda
   }
 }
 
-public static void fillWithNodata(final WritableRaster raster, final Number[] nodata)
+public static void fillWithNodata(final WritableRaster raster, final double[] nodata)
 {
   if (raster.getNumBands() != nodata.length)
   {
@@ -327,20 +327,20 @@ public static void fillWithNodata(final WritableRaster raster, final Number[] no
     case DataBuffer.TYPE_SHORT:
     case DataBuffer.TYPE_USHORT:
       final int[] intsamples = new int[elements];
-      final int inodata = nodata[b].intValue();
+      final int inodata = (int)nodata[b];
       Arrays.fill(intsamples, inodata);
       raster.setSamples(0, 0, raster.getWidth(), raster.getHeight(), b, intsamples);
       break;
     case DataBuffer.TYPE_FLOAT:
       final float[] floatsamples = new float[elements];
 
-      final float fnodata = nodata[b].floatValue();
+      final float fnodata = (float)nodata[b];
       Arrays.fill(floatsamples, fnodata);
       raster.setSamples(0, 0, raster.getWidth(), raster.getHeight(), b, floatsamples);
       break;
     case DataBuffer.TYPE_DOUBLE:
       final double[] doublesamples = new double[elements];
-      Arrays.fill(doublesamples, nodata[b].doubleValue());
+      Arrays.fill(doublesamples, nodata[b]);
       raster.setSamples(0, 0, raster.getWidth(), raster.getHeight(), b, doublesamples);
       break;
     default:
@@ -351,7 +351,7 @@ public static void fillWithNodata(final WritableRaster raster, final Number[] no
 }
 
 private static void copyPixel(final int x, final int y, final int b, final Raster src,
-    final WritableRaster dst, Number nodata)
+    final WritableRaster dst, Double nodata)
 {
 
   switch (src.getTransferType())
@@ -433,7 +433,7 @@ public static void mosaicTile(final Raster src, final WritableRaster dst, final 
   }
 }
 
-public static void mosaicTile(final Raster src, final WritableRaster dst, final Number[] nodatas)
+public static void mosaicTile(final Raster src, final WritableRaster dst, final Double[] nodatas)
 {
   double[] dnodata = new double[nodatas.length];
   for (int i = 0; i < dnodata.length; i++)
@@ -477,7 +477,7 @@ public static WritableRaster makeRasterWritable(final Raster raster)
 // Also used was http://www.compuphase.com/graphic/scale.htm, explaining interpolated
 // scaling
 public static WritableRaster scaleRaster(final Raster src, final int dstWidth,
-    final int dstHeight, final boolean interpolate, final Number nodata)
+    final int dstHeight, final boolean interpolate, final Double nodata)
 {
   final int type = src.getTransferType();
 
@@ -566,7 +566,7 @@ public static WritableRaster scaleRaster(final Raster src, final int dstWidth,
 }
 
 public static WritableRaster scaleRasterInterp(final Raster src, final int dstWidth,
-    final int dstHeight, final Number nodata)
+    final int dstHeight, final Double nodata)
 {
   return scaleRaster(src, dstWidth, dstHeight, true, nodata);
 }
@@ -1159,12 +1159,12 @@ public static void decimate(final Raster parent, final WritableRaster child, fin
 }
 
 public static void decimate(final Raster parent, final WritableRaster child,
-    final Aggregator aggregator, final Number[] nodatas)
+    final Aggregator aggregator, final double[] nodatas)
 {
   decimate(parent, child, 0, 0, aggregator, nodatas);
 }
 
-public static void decimate(final Raster parent, final WritableRaster child, final int startX, final int startY, final Aggregator aggregator, final Number[] nodatas)
+public static void decimate(final Raster parent, final WritableRaster child, final int startX, final int startY, final Aggregator aggregator, final double[] nodatas)
 {
   final int w = parent.getWidth();
   final int h = parent.getHeight();
@@ -1183,19 +1183,19 @@ public static void decimate(final Raster parent, final WritableRaster child, fin
         case DataBuffer.TYPE_USHORT:
           final int[] intsamples = new int[4];
           parent.getSamples(x, y, 2, 2, b, intsamples);
-          int intSample = aggregator.aggregate(intsamples, nodatas[b].intValue());
+          int intSample = aggregator.aggregate(intsamples, (int)nodatas[b]);
           child.setSample(startX + (x / 2), startY + (y / 2), b, intSample);
           break;
         case DataBuffer.TYPE_FLOAT:
           final float[] floatsamples = new float[4];
           parent.getSamples(x, y, 2, 2, b, floatsamples);
-          float floatSample = aggregator.aggregate(floatsamples, nodatas[b].floatValue());
+          float floatSample = aggregator.aggregate(floatsamples, (float)nodatas[b]);
           child.setSample(startX + (x / 2), startY + (y / 2), b, floatSample);
           break;
         case DataBuffer.TYPE_DOUBLE:
           final double[] doublesamples = new double[4];
           parent.getSamples(x, y, 2, 2, b, doublesamples);
-          double doubleSample = aggregator.aggregate(doublesamples, nodatas[b].doubleValue());
+          double doubleSample = aggregator.aggregate(doublesamples, nodatas[b]);
           child.setSample(startX + (x / 2), startY + (y / 2), b, doubleSample);
           break;
         default:

--- a/mrgeo-core/src/main/java/org/mrgeo/image/MrsPyramidMetadata.java
+++ b/mrgeo-core/src/main/java/org/mrgeo/image/MrsPyramidMetadata.java
@@ -858,15 +858,9 @@ public short[] getDefaultValuesShort()
 }
 
 @JsonIgnore
-public Number[] getDefaultValuesNumber()
+public double[] getDefaultValuesNumber()
 {
-  final Number[] defaults = new Number[bands];
-  for (int i = 0; i < bands; i++)
-  {
-    defaults[i] = defaultValues[i];
-  }
-
-  return defaults;
+  return Arrays.copyOf(defaultValues, defaultValues.length);
 }
 
 public ImageMetadata[] getImageMetadata()

--- a/mrgeo-core/src/main/scala/org/mrgeo/ingest/IngestInputProcessor.scala
+++ b/mrgeo-core/src/main/scala/org/mrgeo/ingest/IngestInputProcessor.scala
@@ -1,0 +1,268 @@
+package org.mrgeo.ingest
+
+import java.io.{File, IOException}
+import java.net.URI
+import javax.annotation.CheckForNull
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileStatus, FileSystem, Path}
+import org.gdal.gdal.{Band, Dataset}
+import org.mrgeo.core.{MrGeoConstants, MrGeoProperties}
+import org.mrgeo.hdfs.utils.HadoopFileUtils
+import org.mrgeo.utils.{GDALUtils, Logging}
+import org.mrgeo.utils.tms.{Bounds, TMSUtils}
+
+import scala.collection.mutable.ListBuffer
+
+@SuppressFBWarnings(value = Array("PZLA_PREFER_ZERO_LENGTH_ARRAYS"), justification = "Need to return null")
+class IngestInputProcessor extends Logging
+{
+  private var conf: Configuration = null
+  private var nodataOverride: Array[Double] = null
+  private var nodata: Option[Array[Double]] = None
+  private var bounds: Option[Bounds] = None
+  private var firstInput: Boolean = true
+  private val inputs = new ListBuffer[String]()
+  private var zoomlevel: Int = -1
+  private var bands: Int = -1
+  private var tiletype: Int = -1
+
+  var skippreprocessing: Boolean = false
+  var local: Boolean = false
+
+  val tilesize = MrGeoProperties.getInstance.getProperty(MrGeoConstants.MRGEO_MRS_TILESIZE,
+    MrGeoConstants.MRGEO_MRS_TILESIZE_DEFAULT).toInt
+
+  def this(conf: Configuration, nodataOverride: Array[Double] = null, zoomlevel: Int = -1,
+           skippreprocessing: Boolean = false) {
+    this()
+    this.conf = conf
+    this.nodataOverride = nodataOverride
+    this.zoomlevel = zoomlevel
+    this.skippreprocessing = skippreprocessing
+    if (this.skippreprocessing && this.zoomlevel < 0) {
+      throw new Exception("When you skip preprocessing during ingest, you must specify a zoom level")
+    }
+  }
+
+  def getInputs = {
+    inputs.toList
+  }
+
+  def getZoomlevel = {
+    zoomlevel
+  }
+
+  def getTiletype = {
+    tiletype
+  }
+
+  def getBands = {
+    bands
+  }
+
+  def getBounds = {
+    bounds.getOrElse(null)
+  }
+
+  @CheckForNull
+  def getNodata = {
+    nodata.getOrElse(null)
+  }
+
+  def processInput(arg: String, recurse: Boolean): Unit = {
+    processInput(arg, recurse, true, false)
+  }
+
+  // Should only be used privately - it is called recursively with the additional internal
+  // parameters existsCheck and argIsDir that help prevent excessive HDFS/S3 access.
+  @SuppressFBWarnings(value = Array("PATH_TRAVERSAL_IN"), justification = "File() used to find GDAL images only")
+  private def processInput(arg: String, recurse: Boolean,
+                   existsCheck: Boolean, argIsDir: Boolean): ListBuffer[String] = {
+    var f: File = null
+    try {
+      f = new File(new URI(arg))
+    }
+    catch {
+      case ignored: Any => {
+        f = new File(arg)
+      }
+    }
+
+    // recurse through directories
+    if (f.isDirectory) {
+      val dir: Array[File] = f.listFiles
+      if (dir != null) {
+        for (s <- dir) {
+          try {
+            if (s.isFile || (s.isDirectory && recurse)) {
+              processInput(s.getCanonicalFile.toURI.toString, recurse, false, s.isDirectory)
+            }
+          }
+          catch {
+            case ignored: IOException => {
+            }
+          }
+        }
+      }
+    }
+    else if (f.isFile) {
+      try {
+        System.out.print("*** checking (local file) " + f.getCanonicalPath)
+        val name: String = f.getCanonicalFile.toURI.toString
+        if (skippreprocessing) {
+          if (firstInput) {
+            firstInput = false
+            val dataset: Dataset = GDALUtils.open(name)
+            if (dataset != null) {
+              try {
+                calculateMinimalParams(dataset)
+              } finally {
+                GDALUtils.close(dataset)
+              }
+            }
+          }
+          inputs += name
+          local = true
+          System.out.println(" accepted ***")
+        }
+        else {
+          val dataset: Dataset = GDALUtils.open(name)
+          if (dataset != null) {
+            calculateParams(dataset)
+            GDALUtils.close(dataset)
+            inputs += name
+            local = true
+            System.out.println(" accepted ***")
+          }
+          else {
+            System.out.println(" can't load ***")
+          }
+        }
+      }
+      catch {
+        case ignored: IOException => {
+          System.out.println(" can't load ***")
+        }
+      }
+    }
+    else {
+      try {
+        val p: Path = new Path(arg)
+        val fs: FileSystem = HadoopFileUtils.getFileSystem(conf, p)
+        if (!existsCheck || fs.exists(p)) {
+          var isADirectory: Boolean = argIsDir
+          if (existsCheck) {
+            val status: FileStatus = fs.getFileStatus(p)
+            isADirectory = status.isDirectory
+          }
+          if (isADirectory && recurse) {
+            val files: Array[FileStatus] = fs.listStatus(p)
+            for (file <- files) {
+              processInput(file.getPath.toUri.toString, true, false, file.isDirectory)
+            }
+          }
+          else {
+            System.out.print("*** checking  " + p.toString)
+            val name: String = p.toUri.toString
+            if (skippreprocessing) {
+              if (firstInput) {
+                firstInput = false
+                val dataset: Dataset = GDALUtils.open(name)
+                if (dataset != null) {
+                  try {
+                    calculateMinimalParams(dataset)
+                  } finally {
+                    GDALUtils.close(dataset)
+                  }
+                }
+              }
+              inputs += name
+              System.out.println(" accepted ***")
+            }
+            else {
+              val dataset: Dataset = GDALUtils.open(name)
+              if (dataset != null) {
+                calculateParams(dataset)
+                GDALUtils.close(dataset)
+                inputs += name
+                System.out.println(" accepted ***")
+              }
+              else {
+                System.out.println(" can't load ***")
+              }
+            }
+          }
+        }
+      }
+      catch {
+        case ignored: IOException => {
+        }
+      }
+    }
+
+    return inputs
+  }
+
+  private def calculateParams(image: Dataset): Unit = {
+    val imageBounds: Bounds = GDALUtils.getBounds(image)
+    log.debug("    image bounds: (lon/lat) " + imageBounds.w + ", " + imageBounds.s + " to " + imageBounds.e + ", " + imageBounds.n)
+    bounds = Some(bounds match {
+      case None => imageBounds
+      case Some(b) => b.expand(imageBounds)
+    })
+    val zx: Int = TMSUtils.zoomForPixelSize(imageBounds.width / image.getRasterXSize, tilesize)
+    val zy: Int = TMSUtils.zoomForPixelSize(imageBounds.height / image.getRasterYSize, tilesize)
+    if (zoomlevel < zx) {
+      zoomlevel = zx
+    }
+    if (zoomlevel < zy) {
+      zoomlevel = zy
+    }
+    if (firstInput) {
+      firstInput = false
+      calculateMinimalParams(image)
+    }
+  }
+
+  private def calculateMinimalParams(image: Dataset): Unit = {
+    bands = image.GetRasterCount
+    tiletype = GDALUtils.toRasterDataBufferType(image.GetRasterBand(1).getDataType)
+    val nd = Array.ofDim[Double](bands)
+    if (nodataOverride == null) {
+      var b: Int = 1
+      while (b <= bands) {
+        val band: Band = image.GetRasterBand(b)
+        val ndValue = new Array[java.lang.Double](1)
+        band.GetNoDataValue(ndValue)
+        if (ndValue(0) != null) {
+          nd(b - 1) = ndValue(0)
+          log.debug("nodata: b: " + nd(b - 1).byteValue + " d: " + nd(b - 1).doubleValue + " f: " + nd(b - 1).floatValue + " i: " + nd(b - 1).intValue + " s: " + nd(b - 1).shortValue + " l: " + nd(b - 1).longValue)
+        }
+        else {
+          log.debug("Unable to retrieve nodata from source, using NaN")
+          nd(b - 1) = Double.NaN
+        }
+        b += 1
+      }
+    }
+    else {
+      if (nodataOverride.length == 1) {
+        for (i <- 0 until bands) {
+          nd(i) = nodataOverride(0)
+        }
+      }
+      else if (nodataOverride.length < bands) {
+        throw new Exception(f"There are too few nodata override values (${nodataOverride.length}) compared to the number of bands ($bands) in the inputs")
+      }
+      else {
+        log.warn(f"There are more nodata values (${nodataOverride.length}) than bands ($bands) in the inputs")
+        for (i <- 0 until bands) {
+          nd(i) = nodataOverride(i)
+        }
+      }
+    }
+    nodata = Some(nd)
+  }
+}

--- a/mrgeo-core/src/main/scala/org/mrgeo/ingest/IngestLocal.scala
+++ b/mrgeo-core/src/main/scala/org/mrgeo/ingest/IngestLocal.scala
@@ -18,24 +18,16 @@ package org.mrgeo.ingest
 
 import java.io.{Externalizable, ObjectInput, ObjectOutput}
 
-import org.apache.hadoop.io.SequenceFile
-import org.apache.hadoop.mapreduce.Job
-import org.apache.hadoop.mapreduce.lib.input.SequenceFileInputFormat
 import org.apache.spark.SparkContext
-import org.apache.spark.rdd.PairRDDFunctions
 import org.mrgeo.data.DataProviderFactory
 import org.mrgeo.data.DataProviderFactory.AccessMode
-import org.mrgeo.data.raster.{RasterUtils, RasterWritable}
-import org.mrgeo.data.rdd.RasterRDD
-import org.mrgeo.data.tile.TileIdWritable
-import org.mrgeo.hdfs.utils.HadoopFileUtils
-import org.mrgeo.utils.{HadoopUtils, SparkUtils}
+import org.mrgeo.utils.SparkUtils
 
 class IngestLocal extends IngestImage with Externalizable {
 
   override def execute(context: SparkContext): Boolean = {
 
-    val ingested = IngestImage.localingest(context, inputs, zoom, tilesize,
+    val ingested = IngestImage.localingest(context, inputs, zoom, skipPreprocessing, tilesize,
       categorical, skipCategoryLoad, nodata, protectionlevel)
 
     val dp = DataProviderFactory.getMrsImageDataProvider(output, AccessMode.OVERWRITE, providerproperties)
@@ -46,7 +38,7 @@ class IngestLocal extends IngestImage with Externalizable {
 
   override def readExternal(in: ObjectInput): Unit = {
     val bands = in.readInt()
-    nodata = Array.ofDim[Number](bands)
+    nodata = Array.ofDim[Double](bands)
     for (band <- 0 until bands) {
       nodata(band) = in.readDouble()
     }

--- a/mrgeo-core/src/main/scala/org/mrgeo/spark/FocalBuilder.scala
+++ b/mrgeo-core/src/main/scala/org/mrgeo/spark/FocalBuilder.scala
@@ -30,7 +30,7 @@ import scala.collection.mutable.ListBuffer
 object FocalBuilder extends Logging {
 
   def create(tiles:RDD[(TileIdWritable, RasterWritable)],
-      bufferX:Int, bufferY:Int, bounds:Bounds, zoom:Int, nodatas:Array[Number], context:SparkContext):RDD[(TileIdWritable, RasterWritable)] = {
+      bufferX:Int, bufferY:Int, bounds:Bounds, zoom:Int, nodatas:Array[Double], context:SparkContext):RDD[(TileIdWritable, RasterWritable)] = {
 
     val sample:Raster = RasterWritable.toRaster(tiles.first()._2)
 

--- a/mrgeo-core/src/main/scala/org/mrgeo/utils/SparkUtils.scala
+++ b/mrgeo-core/src/main/scala/org/mrgeo/utils/SparkUtils.scala
@@ -413,7 +413,7 @@ object SparkUtils extends Logging {
   }
 
   def saveMrsPyramid(tiles: RasterRDD, outputProvider: MrsImageDataProvider,
-      zoom: Int, tilesize: Int, nodatas: Array[Number], conf: Configuration, tiletype: Int = -1,
+      zoom: Int, tilesize: Int, nodatas: Array[Double], conf: Configuration, tiletype: Int = -1,
       bounds: Bounds = null, bands: Int = -1,
       protectionlevel:String = null, providerproperties:ProviderProperties = new ProviderProperties()): Unit = {
 
@@ -480,13 +480,13 @@ object SparkUtils extends Logging {
 
   @deprecated("Use RasterRDD method instead", "")
   def calculateStats(rdd: RDD[(TileIdWritable, RasterWritable)], bands: Int,
-      nodata: Array[Number]): Array[ImageStats] = {
+      nodata: Array[Double]): Array[ImageStats] = {
 
     calculateStats(RasterRDD(rdd), bands, nodata)
   }
 
   def calculateStats(rdd: RasterRDD, bands: Int,
-      nodata: Array[Number]): Array[ImageStats] = {
+      nodata: Array[Double]): Array[ImageStats] = {
 
     val zero = Array.ofDim[ImageStats](bands)
 
@@ -650,7 +650,7 @@ object SparkUtils extends Logging {
   }
 
   def calculateBoundsAndStats(rdd: RasterRDD, bands: Int, zoom: Int, tilesize: Int,
-      nodata: Array[Number]): (Bounds, Array[ImageStats]) = {
+      nodata: Array[Double]): (Bounds, Array[ImageStats]) = {
     val zero = Array.ofDim[ImageStats](bands)
 
     for (i <- zero.indices) {
@@ -760,7 +760,7 @@ object SparkUtils extends Logging {
 
   @deprecated("Use RasterRDD method instead", "")
   def saveMrsPyramidRDD(tiles: RDD[(TileIdWritable, RasterWritable)], outputProvider: MrsImageDataProvider,
-      zoom: Int, tilesize: Int, nodatas: Array[Number], conf: Configuration, tiletype: Int = -1,
+      zoom: Int, tilesize: Int, nodatas: Array[Double], conf: Configuration, tiletype: Int = -1,
       bounds: Bounds = null, bands: Int = -1,
       protectionlevel:String = null, providerproperties:ProviderProperties = new ProviderProperties()): Unit = {
 
@@ -781,7 +781,7 @@ object SparkUtils extends Logging {
     calculateMetadata(rdd, zoom, nodatas, calcStats, bounds)
   }
 
-  def calculateMetadata(rdd:RasterRDD, zoom:Int, nodatas:Array[Number], calcStats:Boolean, bounds:Bounds):MrsPyramidMetadata = {
+  def calculateMetadata(rdd:RasterRDD, zoom:Int, nodatas:Array[Double], calcStats:Boolean, bounds:Bounds):MrsPyramidMetadata = {
     val meta = new MrsPyramidMetadata
 
     //    rdd.persist(StorageLevel.MEMORY_AND_DISK_SER)

--- a/mrgeo-core/src/test/java/org/mrgeo/data/raster/RasterUtilsTest.java
+++ b/mrgeo-core/src/test/java/org/mrgeo/data/raster/RasterUtilsTest.java
@@ -153,7 +153,7 @@ public class RasterUtilsTest
 
     scale = 2;
     scaled = RasterUtils.scaleRasterInterp(numberedFloat, 
-        numberedFloat.getWidth() * scale, numberedFloat.getHeight() * scale, Float.NaN);
+        numberedFloat.getWidth() * scale, numberedFloat.getHeight() * scale, Double.NaN);
 
     //    TestUtils.saveRaster(scaled, "TIFF", "scaled.tif");
     //    // scale up

--- a/mrgeo-core/src/test/scala/org/mrgeo/mapalgebra/utils/RasterMapOpTestSupport.scala
+++ b/mrgeo-core/src/test/scala/org/mrgeo/mapalgebra/utils/RasterMapOpTestSupport.scala
@@ -107,7 +107,7 @@ trait RasterMapOpTestSupport {
     // default implementation doesn't use tileId.  It's there for a generator that might.
     case Some(dataArray) => {
       val raster = RasterUtils.createEmptyRaster(tileSize, tileSize, dataArray.size, DataBuffer.TYPE_DOUBLE)
-      RasterUtils.fillWithNodata(raster, dataArray.map(java.lang.Double.valueOf(_)).asInstanceOf[Array[java.lang.Number]])
+      RasterUtils.fillWithNodata(raster, dataArray.map(java.lang.Double.valueOf(_)).asInstanceOf[Array[Double]])
       raster
     }
 

--- a/mrgeo-mapalgebra/mrgeo-mapalgebra-image/src/main/scala/org/mrgeo/mapalgebra/BandCombineMapOp.scala
+++ b/mrgeo-mapalgebra/mrgeo-mapalgebra-image/src/main/scala/org/mrgeo/mapalgebra/BandCombineMapOp.scala
@@ -85,7 +85,7 @@ class BandCombineMapOp extends RasterMapOp with Externalizable {
     }
 
     val pyramids = Array.ofDim[RasterRDD](inputs.length)
-    val nodatabuilder = mutable.ArrayBuilder.make[Number]()
+    val nodatabuilder = mutable.ArrayBuilder.make[Double]()
 
     var i: Int = 0
     var zoom: Int = -1

--- a/mrgeo-mapalgebra/mrgeo-mapalgebra-image/src/main/scala/org/mrgeo/mapalgebra/FocalStatMapOp.scala
+++ b/mrgeo-mapalgebra/mrgeo-mapalgebra-image/src/main/scala/org/mrgeo/mapalgebra/FocalStatMapOp.scala
@@ -40,7 +40,7 @@ class FocalStatMapOp extends RawFocalMapOp with Externalizable {
   private var neighborhoodPixels: Int = 0
   private var ignoreNoData: Boolean = false
   private var outputTileType: Option[Int] = None
-  private var outputNoDatas: Option[Array[Number]] = None
+  private var outputNoDatas: Option[Array[Double]] = None
   private var neighborhoodValues: Array[Double] = null
 
   private[mapalgebra] def this(raster:Option[RasterMapOp], stat:String, neighborhoodSize: String,
@@ -120,7 +120,7 @@ class FocalStatMapOp extends RawFocalMapOp with Externalizable {
     stat.toLowerCase match {
       case FocalStatMapOp.Count =>
         outputTileType = Some(DataBuffer.TYPE_INT)
-        outputNoDatas = Some(Array.fill[Number](meta.getBands)(Int.MinValue))
+        outputNoDatas = Some(Array.fill[Double](meta.getBands)(Int.MinValue))
       case FocalStatMapOp.Max | FocalStatMapOp.Min | FocalStatMapOp.Range =>
         outputTileType = Some(meta.getTileType)
         val nodatas = meta.getDefaultValuesNumber
@@ -128,7 +128,7 @@ class FocalStatMapOp extends RawFocalMapOp with Externalizable {
       case FocalStatMapOp.Mean | FocalStatMapOp.Median | FocalStatMapOp.StdDev |
            FocalStatMapOp.Sum | FocalStatMapOp.Variance =>
         outputTileType = Some(DataBuffer.TYPE_FLOAT)
-        outputNoDatas = Some(Array.fill[Number](meta.getBands)(Float.NaN))
+        outputNoDatas = Some(Array.fill[Double](meta.getBands)(Float.NaN))
     }
   }
 
@@ -143,7 +143,7 @@ class FocalStatMapOp extends RawFocalMapOp with Externalizable {
     }
   }
 
-  override protected def getOutputNoData: Array[Number] = {
+  override protected def getOutputNoData: Array[Double] = {
     outputNoDatas match {
       case Some(nodatas) => nodatas
       case None => throw new IllegalStateException("The output nodata values have not been set")
@@ -327,7 +327,7 @@ class FocalStatMapOp extends RawFocalMapOp with Externalizable {
     val hasNoData = in.readBoolean()
     outputNoDatas = if (hasNoData) {
       val len = in.readInt()
-      val nd = Array.fill[Number](len)(0.0)
+      val nd = Array.fill[Double](len)(0.0)
       for (i <- 0 until len) {
         nd(i) = in.readDouble()
       }

--- a/mrgeo-mapalgebra/mrgeo-mapalgebra-image/src/main/scala/org/mrgeo/mapalgebra/IngestImageMapOp.scala
+++ b/mrgeo-mapalgebra/mrgeo-mapalgebra-image/src/main/scala/org/mrgeo/mapalgebra/IngestImageMapOp.scala
@@ -17,22 +17,16 @@
 package org.mrgeo.mapalgebra
 
 import java.io._
-import java.net.URI
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings
-import org.apache.hadoop.fs.Path
 import org.apache.spark.{SparkConf, SparkContext}
-import org.mrgeo.core.{MrGeoConstants, MrGeoProperties}
 import org.mrgeo.data.rdd.RasterRDD
-import org.mrgeo.hdfs.utils.HadoopFileUtils
 import org.mrgeo.image.MrsPyramidMetadata
-import org.mrgeo.ingest.IngestImage
+import org.mrgeo.ingest.{IngestImage, IngestInputProcessor}
 import org.mrgeo.job.JobArguments
 import org.mrgeo.mapalgebra.parser.{ParserException, ParserNode}
 import org.mrgeo.mapalgebra.raster.RasterMapOp
-import org.mrgeo.utils.GDALUtils
-
-import scala.util.control.Breaks
+import org.mrgeo.utils.tms.TMSUtils
 
 object IngestImageMapOp extends MapOpRegistrar {
 
@@ -45,9 +39,21 @@ object IngestImageMapOp extends MapOpRegistrar {
   // call MrGeo.ingest_image(). Define createMapOp methods instead so that MrGeo.ingest_image
   // can call those methods.
 
-  def createMapOp(input:String, zoom:Int, categorical:Boolean, skip_category_load: Boolean,
-                  protectionLevel: String):MapOp =
-    new IngestImageMapOp(input, Some(zoom), Some(categorical), Some(skip_category_load), protectionLevel)
+  def createMapOp(input:String, zoom:Int, skip_preprocessing: Boolean, nodataOverride: Array[Double],
+                  categorical:Boolean, skip_category_load: Boolean, protectionLevel: String):MapOp = {
+    if (nodataOverride == null) {
+      new IngestImageMapOp(input, Some(zoom), None, Some(skip_preprocessing), Some(categorical),
+        Some(skip_category_load), protectionLevel)
+    }
+    else {
+      val ndo = Array.ofDim[Double](nodataOverride.length)
+      nodataOverride.zipWithIndex.foreach(U => {
+        ndo(U._2) = U._1
+      })
+      new IngestImageMapOp(input, Some(zoom), Some(ndo), Some(skip_preprocessing), Some(categorical),
+        Some(skip_category_load), protectionLevel)
+    }
+  }
 
   override def apply(node:ParserNode, variables: String => Option[ParserNode]): MapOp =
     new IngestImageMapOp(node, variables)
@@ -59,12 +65,15 @@ class IngestImageMapOp extends RasterMapOp with Externalizable {
   private var rasterRDD: Option[RasterRDD] = None
 
   private var inputs:Option[Array[String]] = None
+  private var nodataOverride: Option[Array[Double]] = None
   private var categorical: Boolean = false
+  private var skipPreprocessing: Boolean = false
   private var skipCategoryLoad = false
   private var zoom = -1
   private var protectionLevel: String = ""
 
-  private[mapalgebra] def this(input:String, zoom:Option[Int], categorical:Option[Boolean],
+  private[mapalgebra] def this(input:String, zoom:Option[Int], nodataOverride: Option[Array[Double]],
+                               skipPreprocessing: Option[Boolean], categorical:Option[Boolean],
                                skipCategoryLoad:Option[Boolean], protectionLevel: String) = {
     this()
     val inputs = Array.ofDim[String](1)
@@ -72,17 +81,22 @@ class IngestImageMapOp extends RasterMapOp with Externalizable {
     this.inputs = Some(inputs)
     this.categorical = categorical.getOrElse(false)
     this.skipCategoryLoad = skipCategoryLoad.getOrElse(false)
+    this.skipPreprocessing = skipPreprocessing.getOrElse(false)
     this.zoom = zoom.getOrElse(-1)
+    this.nodataOverride = nodataOverride
     this.protectionLevel = protectionLevel
   }
 
-  private[mapalgebra] def this(inputs:Array[String], zoom:Option[Int], categorical:Option[Boolean],
+  private[mapalgebra] def this(inputs:Array[String], zoom:Option[Int], nodataOverride: Option[Array[Double]],
+                               skipPreprocessing: Option[Boolean], categorical:Option[Boolean],
                                skipCategoryLoad:Option[Boolean], protectionLevel: String) = {
     this()
     this.inputs = Some(inputs)
     this.categorical = categorical.getOrElse(false)
     this.skipCategoryLoad = skipCategoryLoad.getOrElse(false)
+    this.skipPreprocessing = skipPreprocessing.getOrElse(false)
     this.zoom = zoom.getOrElse(-1)
+    this.nodataOverride = nodataOverride
     this.protectionLevel = protectionLevel
   }
 
@@ -90,7 +104,7 @@ class IngestImageMapOp extends RasterMapOp with Externalizable {
     this()
 
     if (node.getNumChildren < 1 || node.getNumChildren > 5) {
-      throw new ParserException("Usage: ingest(input(s), [zoom], [categorical], [skipCategoryLoad], [protectionLevel]")
+      throw new ParserException("Usage: ingest(input(s), [zoom], [skippreprocessing], [nodata values], [categorical], [skipCategoryLoad], [protectionLevel]")
     }
 
     val in = Array.ofDim[String](1)
@@ -98,19 +112,63 @@ class IngestImageMapOp extends RasterMapOp with Externalizable {
     this.inputs = Some(in)
 
     if (node.getNumChildren >= 2) {
-      zoom = MapOp.decodeInt(node.getChild(1), variables).getOrElse(-1)
+      zoom = MapOp.decodeInt(node.getChild(1), variables).getOrElse(
+        throw new ParserException(f"Expected integer value for zoom instead of ${node.getChild(1).toString}"))
+      if (zoom < 1 || zoom > TMSUtils.MAXZOOMLEVEL) {
+        throw new ParserException(f"Invalid zoom ${node.getChild(1).toString}")
+      }
     }
 
     if (node.getNumChildren >= 3) {
-      categorical = MapOp.decodeBoolean(node.getChild(2), variables).getOrElse(false)
+      skipPreprocessing = MapOp.decodeBoolean(node.getChild(2), variables).getOrElse(
+        throw new ParserException(f"Expected boolean value for skippreprocessing instead of ${node.getChild(2).toString}"))
     }
 
     if (node.getNumChildren >= 4) {
-      skipCategoryLoad = MapOp.decodeBoolean(node.getChild(3), variables).getOrElse(false)
+      val str = MapOp.decodeString(node.getChild(3), variables).getOrElse(throw new ParserException("Missing nodata values"))
+      if (str.trim.length > 0) {
+        val strElements = str.split(",")
+        val nodataOverrideValues = Array.ofDim[Double](strElements.length)
+        for (i <- 0 until nodataOverrideValues.length) {
+          try {
+            nodataOverrideValues(i) = parseNoData(strElements(i));
+          }
+          catch {
+            case nfe: NumberFormatException => {
+              throw new ParserException("Invalid nodata value " + strElements(i))
+            }
+          }
+        }
+        nodataOverride = Some(nodataOverrideValues)
+      }
     }
 
     if (node.getNumChildren >= 5) {
-      protectionLevel = MapOp.decodeString(node.getChild(4), variables).getOrElse("")
+      categorical = MapOp.decodeBoolean(node.getChild(4), variables).getOrElse(
+        throw new ParserException(f"Expected boolean value for categorical instead of ${node.getChild(4).toString}"))
+    }
+
+    if (node.getNumChildren >= 6) {
+      skipCategoryLoad = MapOp.decodeBoolean(node.getChild(5), variables).getOrElse(
+        throw new ParserException(f"Expected boolean value for skipCategoryLoad instead of ${node.getChild(5).toString}"))
+    }
+
+    if (node.getNumChildren >= 7) {
+      protectionLevel = MapOp.decodeString(node.getChild(6), variables).getOrElse(
+        throw new ParserException(f"Expected string value for protectionLevel instead of ${node.getChild(6).toString}"))
+    }
+  }
+
+  private def parseNoData(fromArg: String): Double =
+  {
+    val arg = fromArg.trim();
+    if (arg.compareToIgnoreCase("nan") != 0)
+    {
+      return arg.toDouble
+    }
+    else
+    {
+      return Double.NaN;
     }
   }
 
@@ -131,90 +189,16 @@ class IngestImageMapOp extends RasterMapOp with Externalizable {
   override def execute(context: SparkContext): Boolean = {
 
     val inputfiles = inputs.getOrElse(throw new IOException("Inputs not set"))
-
-    val filebuilder = Array.newBuilder[String]
-
-    for (inputfile <- inputfiles) {
-      var f: File = null
-      try {
-        f = new File(new URI(inputfile))
-      }
-      catch {
-        case ignored: Any => f = new File(inputfile)
-      }
-
-      def walk(dir: File): Array[String] = {
-        val files = Array.newBuilder[String]
-        val dir: Array[File] = f.listFiles
-        if (dir != null) {
-          for (s <- dir) {
-            try {
-              if (s.isFile) {
-                files += s.toURI.toString
-              }
-              else if (s.isDirectory) {
-                files ++= walk(s)
-              }
-            }
-          }
-        }
-        files.result()
-      }
-
-      if (f.exists()) {
-        if (f.isFile) {
-          filebuilder += f.toURI.toString
-        }
-        else if (f.isDirectory) {
-          filebuilder ++= walk(f)
-        }
-      }
-      else {
-        val path = new Path(inputfile)
-        val fs = HadoopFileUtils.getFileSystem(context.hadoopConfiguration, path)
-
-        val rawfiles = fs.listFiles(path, true)
-
-        while (rawfiles.hasNext) {
-          val raw = rawfiles.next()
-
-          if (!raw.isDirectory) {
-            filebuilder += raw.getPath.toUri.toString
-          }
-        }
-      }
-    }
-
-    val tilesize = MrGeoProperties.getInstance().getProperty(MrGeoConstants.MRGEO_MRS_TILESIZE, MrGeoConstants.MRGEO_MRS_TILESIZE_DEFAULT).toInt
-
-    if (zoom < 0) {
-      var newZoom = 1
-      filebuilder.result().foreach(file => {
-        val z = GDALUtils.calculateZoom(file, tilesize)
-        if (z > newZoom) {
-          newZoom = z
-        }
-      })
-      zoom = newZoom
-    }
-
-    var nodatas:Array[Number] = null
-
-    val done = new Breaks
-    done.breakable({
-      filebuilder.result().foreach(file => {
-        try {
-          nodatas = GDALUtils.getnodatas(file)
-          done.break()
-        }
-        catch {
-          case e:Exception => // ignore and go on
-        }
-      })
+    val iip = new IngestInputProcessor(context.hadoopConfiguration,
+      nodataOverride match {
+        case None => null
+        case Some(ndo) => ndo
+      }, zoom, skipPreprocessing)
+    inputfiles.foreach(input => {
+      iip.processInput(input, true)
     })
-
-    val result = IngestImage.ingest(context, filebuilder.result(), zoom, tilesize,
-      categorical, skipCategoryLoad, nodatas, protectionLevel)
+    val result = IngestImage.ingest(context, iip.getInputs.toArray, iip.getZoomlevel, skipPreprocessing, iip.tilesize,
+      categorical, skipCategoryLoad, iip.getNodata, protectionLevel)
     rasterRDD = result._1 match {
     case rrdd:RasterRDD =>
       rrdd.checkpoint()

--- a/mrgeo-mapalgebra/mrgeo-mapalgebra-image/src/main/scala/org/mrgeo/mapalgebra/KernelMapOp.scala
+++ b/mrgeo-mapalgebra/mrgeo-mapalgebra-image/src/main/scala/org/mrgeo/mapalgebra/KernelMapOp.scala
@@ -155,7 +155,7 @@ class KernelMapOp extends RasterMapOp with Externalizable {
     true
   }
 
-  def naiveKernel(focal:RDD[(TileIdWritable, RasterWritable)], kernel:Kernel, nodatas:Array[Float],
+  def naiveKernel(focal:RDD[(TileIdWritable, RasterWritable)], kernel:Kernel, nodatas:Array[Double],
       context: SparkContext):RDD[(TileIdWritable, RasterWritable)] = {
 
     val weights = context.broadcast(kernel.getKernel.get)

--- a/mrgeo-mapalgebra/mrgeo-mapalgebra-image/src/main/scala/org/mrgeo/mapalgebra/RawFocalMapOp.scala
+++ b/mrgeo-mapalgebra/mrgeo-mapalgebra-image/src/main/scala/org/mrgeo/mapalgebra/RawFocalMapOp.scala
@@ -35,7 +35,7 @@ abstract class RawFocalMapOp extends RasterMapOp with Externalizable {
 
   protected var inputMapOp: Option[RasterMapOp] = None
   private var rasterRDD:Option[RasterRDD] = None
-  private var outputNoDatas: Option[Array[Number]] = None
+  private var outputNoDatas: Option[Array[Double]] = None
 
   override def rdd(): Option[RasterRDD] = rasterRDD
 
@@ -109,7 +109,7 @@ abstract class RawFocalMapOp extends RasterMapOp with Externalizable {
     * @param meta
     */
   protected def beforeExecute(meta: MrsPyramidMetadata): Unit = {
-    outputNoDatas = Some(Array.fill[Number](meta.getBands)(Double.NaN))
+    outputNoDatas = Some(Array.fill[Double](meta.getBands)(Double.NaN))
   }
 
   private def isNoData(value: Double, nodata: Double): Boolean =
@@ -135,7 +135,7 @@ abstract class RawFocalMapOp extends RasterMapOp with Externalizable {
     DataBuffer.TYPE_FLOAT
   }
 
-  protected def getOutputNoData: Array[Number] = {
+  protected def getOutputNoData: Array[Double] = {
     outputNoDatas match {
       case Some(nodatas) => nodatas
       case None => throw new IllegalStateException("The output nodata values have not been set")
@@ -150,7 +150,7 @@ abstract class RawFocalMapOp extends RasterMapOp with Externalizable {
   private def calculate(tiles:RDD[(TileIdWritable, RasterWritable)],
                         bufferX: Int, bufferY: Int,
                         neighborhoodWidth: Int, neighborhoodHeight: Int,
-                        nodatas:Array[Number], zoom:Int, tilesize:Int) =
+                        nodatas:Array[Double], zoom:Int, tilesize:Int) =
   {
     val outputNoData = getOutputNoData
     tiles.map(tile => {
@@ -188,7 +188,7 @@ abstract class RawFocalMapOp extends RasterMapOp with Externalizable {
         val notnodata = new Array[Boolean](rasterWidth * rasterHeight)
         var i: Int = 0
         while (i < rasterValues.length) {
-          notnodata(i) = !isNoData(rasterValues(i), nodatas(band).doubleValue())
+          notnodata(i) = !isNoData(rasterValues(i), nodatas(band))
           i += 1
         }
         var py = 0
@@ -199,7 +199,7 @@ abstract class RawFocalMapOp extends RasterMapOp with Externalizable {
             val index = calculateRasterIndex(rasterWidth, px, py)
             val v = raster.getSampleDouble(px, py, band)
             rasterValues(index) = v
-            if (!isNoData(v, nodatas(band).doubleValue())) {
+            if (!isNoData(v, nodatas(band))) {
               notnodata(index) = true
             }
             else {

--- a/mrgeo-mapalgebra/mrgeo-mapalgebra-integrationtests/src/test/scala/org/mrgeo/mapalgebra/QuantilesMapOpTest.scala
+++ b/mrgeo-mapalgebra/mrgeo-mapalgebra-integrationtests/src/test/scala/org/mrgeo/mapalgebra/QuantilesMapOpTest.scala
@@ -259,22 +259,13 @@ class QuantilesMapOpTest extends LocalRunnerTest with AssertionsForJUnit
     val metadata = metadataReader.read()
     Assert.assertNotNull("Unable to read metadata", metadata)
     val quantiles = metadata.getQuantiles(0)
-    // Make sure each quantile value is different than what would be expected
-    // from the quantile computation based on the full set of data. But they should
-    // at least be within a close range of those values.
-    // NOTE: theoretically, the SAMPLED_EPSILON should be calculated using some
-    // statistical principals.
-    validateQuantileEstimate(67.483246, 0, quantiles)
+    // Check to see if the quantile values are at least close to the values that would
+    // be returned when all of the pixels are used in the quantiles computation. We
+    // may need to revisit this check if we start to see this test fail because the
+    // resulting quantiles will be different every time the test is run (since it
+    // used random pixel values).
     Assert.assertEquals(67.483246, quantiles(0), QuantilesMapOpTest.SAMPLED_EPSILON)
-    validateQuantileEstimate(87.27524, 1, quantiles)
     Assert.assertEquals(87.27524, quantiles(1), QuantilesMapOpTest.SAMPLED_EPSILON)
-    validateQuantileEstimate(110.95636, 2, quantiles)
     Assert.assertEquals(110.95636, quantiles(2), QuantilesMapOpTest.SAMPLED_EPSILON)
-  }
-
-  private def validateQuantileEstimate(exactValue: Double, quantile:Int, quantiles: Array[Double]): Unit = {
-    Assert.assertTrue(s"Quantile ${quantile + 1} should not match the exact quantile value",
-      ((quantiles(quantile) < (exactValue - QuantilesMapOpTest.EPSILON)) ||
-        (quantiles(quantile) > (exactValue + QuantilesMapOpTest.EPSILON))))
   }
 }

--- a/mrgeo-mapalgebra/mrgeo-mapalgebra-terrain/src/main/java/org/mrgeo/mapalgebra/SlopeAspectMapOp.scala
+++ b/mrgeo-mapalgebra/mrgeo-mapalgebra-terrain/src/main/java/org/mrgeo/mapalgebra/SlopeAspectMapOp.scala
@@ -187,7 +187,7 @@ abstract class SlopeAspectMapOp extends RasterMapOp with Externalizable {
     rasterRDD =
         Some(RasterRDD(calculate(tiles, bufferX, bufferY, nodatas(0).doubleValue(), zoom, tilesize)))
 
-    metadata(SparkUtils.calculateMetadata(rasterRDD.get, zoom, Array[Number](Float.NaN),
+    metadata(SparkUtils.calculateMetadata(rasterRDD.get, zoom, Array[Double](Double.NaN),
       bounds = meta.getBounds, calcStats = false))
 
     true

--- a/mrgeo-mapalgebra/mrgeo-mapalgebra-terrain/src/main/scala/org/mrgeo/mapalgebra/Slope8MapOp.scala
+++ b/mrgeo-mapalgebra/mrgeo-mapalgebra-terrain/src/main/scala/org/mrgeo/mapalgebra/Slope8MapOp.scala
@@ -297,7 +297,7 @@ class Slope8MapOp extends RasterMapOp with Externalizable {
         Some(RasterRDD(calculate(tiles, bufferX, bufferY, nodatas(0).doubleValue(), zoom, tilesize)))
 
 
-    metadata(SparkUtils.calculateMetadata(rasterRDD.get, zoom, Array.fill(8)(Float.NaN.asInstanceOf[Number]),
+    metadata(SparkUtils.calculateMetadata(rasterRDD.get, zoom, Array.fill(8)(Double.NaN),
       bounds = meta.getBounds, calcStats = false))
 
     true

--- a/mrgeo-python/src/main/python/pymrgeo/mrgeo.py
+++ b/mrgeo-python/src/main/python/pymrgeo/mrgeo.py
@@ -238,7 +238,8 @@ class MrGeo(object):
 
         return RasterMapOp(mapop=mapop, gateway=self.gateway, context=self.sparkContext, job=self._job)
 
-    def ingest_image(self, name, zoom=-1, categorical=False, skip_category_load=False):
+    def ingest_image(self, name, zoom=-1, skip_preprocessing=False, nodata_override=None,
+                     categorical=False, skip_category_load=False, protection_level=""):
         if not self._started:
             print("ERROR:  You must call start() before ingest_image()")
             sys.stdout.flush()
@@ -247,7 +248,8 @@ class MrGeo(object):
         jvm = self._get_jvm()
         job = self._get_job()
 
-        mapop = jvm.IngestImageMapOp.createMapOp(name, zoom, categorical, skip_category_load)
+        mapop = jvm.IngestImageMapOp.createMapOp(name, zoom, skip_preprocessing, nodata_override,
+                                                 categorical, skip_category_load, protection_level)
 
         if (mapop.setup(job, self.sparkContext.getConf()) and
                 mapop.execute(self.sparkContext) and

--- a/mrgeo-services/mrgeo-services-core/src/main/java/org/mrgeo/services/mrspyramid/MrsPyramidService.java
+++ b/mrgeo-services/mrgeo-services-core/src/main/java/org/mrgeo/services/mrspyramid/MrsPyramidService.java
@@ -175,19 +175,19 @@ public class MrsPyramidService {
       ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
       int bands;
-      Double[] nodatas;
+      double[] nodatas;
       if (format.equalsIgnoreCase("jpg") || format.equalsIgnoreCase("jpeg") )
       {
         bands = 3;
-        nodatas = new Double[]{0.0,0.0,0.0};
+        nodatas = new double[]{0.0,0.0,0.0};
       } else
       {
         bands = 4;
-        nodatas = new Double[]{0.0,0.0,0.0,0.0};
+        nodatas = new double[]{0.0,0.0,0.0,0.0};
       }
 
       Raster raster = RasterUtils.createEmptyRaster(width, height, bands, DataBuffer.TYPE_BYTE, nodatas);
-      writer.writeToStream(raster, ArrayUtils.toPrimitive(nodatas), baos);
+      writer.writeToStream(raster, nodatas, baos);
       byte[] imageData = baos.toByteArray();
       IOUtils.closeQuietly(baos);
       return imageData;

--- a/mrgeo-services/mrgeo-services-tms/src/main/java/org/mrgeo/resources/tms/TileMapServiceResource.java
+++ b/mrgeo-services/mrgeo-services-tms/src/main/java/org/mrgeo/resources/tms/TileMapServiceResource.java
@@ -732,19 +732,19 @@ Response returnEmptyTile(final int width, final int height,
   ByteArrayOutputStream baos = new ByteArrayOutputStream();
 
   int bands;
-  Double[] nodatas;
+  double[] nodatas;
   if (format.equalsIgnoreCase("jpg") || format.equalsIgnoreCase("jpeg") )
   {
     bands = 3;
-    nodatas = new Double[]{0.0,0.0,0.0};
+    nodatas = new double[]{0.0,0.0,0.0};
   } else
   {
     bands = 4;
-    nodatas = new Double[]{0.0,0.0,0.0,0.0};
+    nodatas = new double[]{0.0,0.0,0.0,0.0};
   }
 
   Raster raster = RasterUtils.createEmptyRaster(width, height, bands, DataBuffer.TYPE_BYTE, nodatas);
-  writer.writeToStream(raster, ArrayUtils.toPrimitive(nodatas), baos);
+  writer.writeToStream(raster, nodatas, baos);
   byte[] imageData = baos.toByteArray();
   IOUtils.closeQuietly(baos);
 


### PR DESCRIPTION
- closes #306
- added parameter for skipping pre-processing of source files
- added parameter for protection level
- fixed an unrelated failure in quantiles test that randomly failed
- changed internal handling of nodata values to use double instead of Number
- wrote common code for processing inputs to be ingested and re-factored the
  command-line ingest and map algebra ingest to use it (IngestInputProcessor)