### PR TITLE
Fixes for issue 394 as well as memory handling for gaussian kernels

### DIFF
--- a/mrgeo-mapalgebra/mrgeo-mapalgebra-image/src/main/scala/org/mrgeo/mapalgebra/BandExtractMapOp.scala
+++ b/mrgeo-mapalgebra/mrgeo-mapalgebra-image/src/main/scala/org/mrgeo/mapalgebra/BandExtractMapOp.scala
@@ -33,7 +33,7 @@ object BandExtractMapOp extends MapOpRegistrar {
     Array[String]("bandextract", "extract", "be")
   }
 
-  def create(raster:RasterMapOp, band:Int = 0) =
+  def create(raster:RasterMapOp, band:Int = 1) =
     new BandExtractMapOp(Some(raster), band)
 
   override def apply(node:ParserNode, variables: String => Option[ParserNode]): MapOp =
@@ -49,7 +49,7 @@ class BandExtractMapOp extends RasterMapOp with Externalizable {
   private[mapalgebra] def this(raster:Option[RasterMapOp], band:Int) = {
     this()
     input = raster
-    this.band = band
+    this.band = band - 1
   }
 
   private[mapalgebra] def this(node:ParserNode, isSlope:Boolean, variables: String => Option[ParserNode]) = {


### PR DESCRIPTION
- closes #394
 - Replace the use of an opencv matrix to keep track of the nodata mask
   with a scala array
 - Use instance variables for the opencv data Matrix and nodata mask to
   limit the amount of memeory allocation and deallocation