### PR TITLE
Set py4j gateway_client to use value from JavaSparkContext

### DIFF
--- a/mrgeo-python/src/main/python/pymrgeo/mrgeo.py
+++ b/mrgeo-python/src/main/python/pymrgeo/mrgeo.py
@@ -88,7 +88,7 @@ class MrGeo(object):
                 self._localGateway = True
             else:
                 self.gateway = pysparkContext._gateway
-                self.gateway_client = self.gateway.gateway_client
+                self.gateway_client = pysparkContext._jsc._gateway_client
                 self.sparkContext = pysparkContext._jsc.sc()
 
             self._create_job()


### PR DESCRIPTION
This is to use an existing SparkContext, the `gateway_client` value needs to be pulled from the JavaSparkContext