### PR TITLE
Small Fix for maven assembly plugin

### DIFF
--- a/distribution/distribution-tgz/pom.xml
+++ b/distribution/distribution-tgz/pom.xml
@@ -124,6 +124,7 @@
               <goal>single</goal>
             </goals>
             <configuration>
+              <tarLongFileMode>posix</tarLongFileMode>
               <descriptors>
                 <descriptor>src/main/assembly/dist.xml</descriptor>
               </descriptors>

--- a/pom.xml
+++ b/pom.xml
@@ -3747,6 +3747,12 @@
         <role>dev ops</role>
       </roles>
     </contributor>
+    <contributor>
+      <name>James McClain</name>
+      <roles>
+        <role>user</role>
+      </roles>
+    </contributor>
   </contributors>
   <scm>
     <connection>scm:git:file://${project.basedir}</connection>


### PR DESCRIPTION
The 2.5.x versions of the plugin seem to be unable to succeed on the `distribution-tgz` target without this change.  More context can be found [here](https://gitter.im/ngageoint/mrgeo?at=588f8ac8e836bf7010ae500a).