### PR TITLE
Fix intermittent test failure

### DIFF
--- a/mrgeo-cmd/mrgeo-cmd-ingest/src/test/java/org/mrgeo/cmd/ingest/IngestImageTest.java
+++ b/mrgeo-cmd/mrgeo-cmd-ingest/src/test/java/org/mrgeo/cmd/ingest/IngestImageTest.java
@@ -36,7 +36,6 @@ import org.mrgeo.test.TestUtils;
 import org.mrgeo.utils.HadoopUtils;
 import org.mrgeo.utils.LongRectangle;
 import org.mrgeo.utils.logging.LoggingUtils;
-import org.mrgeo.utils.tms.Bounds;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -105,10 +104,11 @@ public static void init() throws IOException
 
   LoggingUtils.setDefaultLogLevel(LoggingUtils.ERROR);
 
-  Properties props = MrGeoProperties.getInstance();
-  origProtectionLevelRequired = props.getProperty(MrGeoConstants.MRGEO_PROTECTION_LEVEL_REQUIRED);
-  origProtectionLevelDefault = props.getProperty(MrGeoConstants.MRGEO_PROTECTION_LEVEL_DEFAULT);
-  origProtectionLevel = props.getProperty(MrGeoConstants.MRGEO_PROTECTION_LEVEL);
+  MrGeoProperties.resetProperties();
+//  Properties props = MrGeoProperties.getInstance();
+//  origProtectionLevelRequired = props.getProperty(MrGeoConstants.MRGEO_PROTECTION_LEVEL_REQUIRED);
+//  origProtectionLevelDefault = props.getProperty(MrGeoConstants.MRGEO_PROTECTION_LEVEL_DEFAULT);
+//  origProtectionLevel = props.getProperty(MrGeoConstants.MRGEO_PROTECTION_LEVEL);
   conf = HadoopUtils.createConfiguration();
 
   testUtils = new TestUtils(IngestImageTest.class);
@@ -126,39 +126,46 @@ public static void init() throws IOException
 
 }
 
+@AfterClass
+public static void finish()
+{
+  MrGeoProperties.resetProperties();
+}
+
 @After
 public void teardown()
 {
   System.setSecurityManager(null); // or save and restore original
 
   // Restore MrGeoProperties
-  Properties props = MrGeoProperties.getInstance();
-  if (origProtectionLevelRequired == null)
-  {
-    props.remove(MrGeoConstants.MRGEO_PROTECTION_LEVEL_REQUIRED);
-  }
-  else
-  {
-    props.setProperty(MrGeoConstants.MRGEO_PROTECTION_LEVEL_REQUIRED, origProtectionLevelRequired);
-  }
-
-  if (origProtectionLevelDefault == null)
-  {
-    props.remove(MrGeoConstants.MRGEO_PROTECTION_LEVEL_DEFAULT);
-  }
-  else
-  {
-    props.setProperty(MrGeoConstants.MRGEO_PROTECTION_LEVEL_DEFAULT, origProtectionLevelDefault);
-  }
-
-  if (origProtectionLevel == null)
-  {
-    props.remove(MrGeoConstants.MRGEO_PROTECTION_LEVEL);
-  }
-  else
-  {
-    props.setProperty(MrGeoConstants.MRGEO_PROTECTION_LEVEL, origProtectionLevel);
-  }
+//  Properties props = MrGeoProperties.getInstance();
+//  if (origProtectionLevelRequired == null)
+//  {
+//    props.remove(MrGeoConstants.MRGEO_PROTECTION_LEVEL_REQUIRED);
+//  }
+//  else
+//  {
+//    props.setProperty(MrGeoConstants.MRGEO_PROTECTION_LEVEL_REQUIRED, origProtectionLevelRequired);
+//  }
+//
+//  if (origProtectionLevelDefault == null)
+//  {
+//    props.remove(MrGeoConstants.MRGEO_PROTECTION_LEVEL_DEFAULT);
+//  }
+//  else
+//  {
+//    props.setProperty(MrGeoConstants.MRGEO_PROTECTION_LEVEL_DEFAULT, origProtectionLevelDefault);
+//  }
+//
+//  if (origProtectionLevel == null)
+//  {
+//    props.remove(MrGeoConstants.MRGEO_PROTECTION_LEVEL);
+//  }
+//  else
+//  {
+//    props.setProperty(MrGeoConstants.MRGEO_PROTECTION_LEVEL, origProtectionLevel);
+//  }
+  MrGeoProperties.resetProperties();
 }
 
 @Before

--- a/mrgeo-core/src/main/java/org/mrgeo/colorscale/ColorScale.java
+++ b/mrgeo-core/src/main/java/org/mrgeo/colorscale/ColorScale.java
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.mrgeo.utils.FloatUtils;
 import org.mrgeo.utils.XmlUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -51,6 +53,7 @@ import java.util.TreeMap;
  */
 public class ColorScale extends TreeMap<Double, Color>
 {
+  private static final Logger log = LoggerFactory.getLogger(ColorScale.class);
 private static final long serialVersionUID = 1L;
 private static final int CACHE_SIZE = 1024;
 private static final int A = 3;
@@ -541,6 +544,7 @@ public void fromXML(final Document doc) throws ColorScaleException
   }
   catch (XPathExpressionException | IOException e)
   {
+    log.error("Got XML error " + e.getMessage(), e);
     throw new BadXMLException(e);
   }
 }
@@ -553,6 +557,7 @@ public void fromXML(final InputStream strm) throws ColorScaleException
   }
   catch (final Exception e)
   {
+    log.error("Got exception while parsing color scale " + e.getMessage(), e);
     throw new ColorScaleException(e);
   }
 }

--- a/mrgeo-core/src/main/java/org/mrgeo/core/MrGeoProperties.java
+++ b/mrgeo-core/src/main/java/org/mrgeo/core/MrGeoProperties.java
@@ -138,8 +138,10 @@ public static String findMrGeoConf() throws IOException
   throw new IOException(MrGeoConstants.MRGEO_CONF_DIR + " not set, or can not find " + file.getCanonicalPath());
 }
 
-// Test method only!   Clear the properties object, so it can be reloaded later.
-static void clearProperties()
+/**
+ * Test method only!   Clear the properties object, so it can be reloaded later.
+ */
+public static void resetProperties()
 {
   properties = null;
 }

--- a/mrgeo-core/src/test/java/org/mrgeo/colorscale/ColorScaleManagerTest.java
+++ b/mrgeo-core/src/test/java/org/mrgeo/colorscale/ColorScaleManagerTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mrgeo.core.MrGeoConstants;
 import org.mrgeo.core.MrGeoProperties;
+import org.mrgeo.core.MrGeoPropertiesTest;
 import org.mrgeo.junit.UnitTest;
 import org.mrgeo.test.TestUtils;
 
@@ -39,19 +40,21 @@ import java.util.Properties;
 public class ColorScaleManagerTest
 {
 
-String oldbase;
+//String oldbase;
 
 @Before
 public void setup() throws ColorScale.ColorScaleException
 {
-  oldbase = MrGeoProperties.getInstance().getProperty(MrGeoConstants.MRGEO_HDFS_COLORSCALE);
+  MrGeoProperties.resetProperties();
+//  oldbase = MrGeoProperties.getInstance().getProperty(MrGeoConstants.MRGEO_HDFS_COLORSCALE);
   ColorScaleManager.resetColorscales();
 }
 
 @After
 public void teardown()
 {
-  MrGeoProperties.getInstance().setProperty(MrGeoConstants.MRGEO_HDFS_COLORSCALE, oldbase);
+//  MrGeoProperties.getInstance().setProperty(MrGeoConstants.MRGEO_HDFS_COLORSCALE, oldbase);
+  MrGeoProperties.resetProperties();
 }
 
 

--- a/mrgeo-core/src/test/java/org/mrgeo/core/MrGeoPropertiesTest.java
+++ b/mrgeo-core/src/test/java/org/mrgeo/core/MrGeoPropertiesTest.java
@@ -25,7 +25,7 @@ private String encryptedValue;
 @Before
 public void setUp() throws Exception
 {
-  MrGeoProperties.clearProperties();
+  MrGeoProperties.resetProperties();
 
   StandardPBEStringEncryptor encryptor = new StandardPBEStringEncryptor();
   encryptor.setPassword(TEST_MASTER_PASSWORD);

--- a/mrgeo-core/src/test/java/org/mrgeo/data/DataProviderFactoryTest.java
+++ b/mrgeo-core/src/test/java/org/mrgeo/data/DataProviderFactoryTest.java
@@ -36,8 +36,6 @@ import org.mrgeo.utils.HadoopUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Properties;
 
 @SuppressWarnings("all") // test code, not included in production
@@ -49,9 +47,9 @@ private static String test_tsv;
 private static String test_tsv_filename = "test1.tsv";
 private static String test_tsv_columns_filename = test_tsv_filename + ".columns";
 private static String test_tsv_input = Defs.INPUT + test_tsv_filename;
-Map<String, String> oldConfValues = null;
-Map<String, String> oldPropValues = null;
-Map<String, String> oldMrGeoValues = null;
+//Map<String, String> oldConfValues = null;
+//Map<String, String> oldPropValues = null;
+//Map<String, String> oldMrGeoValues = null;
 private ProviderProperties providerProperties;
 
 @BeforeClass
@@ -617,17 +615,17 @@ public void testPreferredProviderFromDefault() throws Exception
 private void setupPreferred(Configuration conf, String confVal,
     String mrgeoVal, String defMrgeoVal)
 {
-
+  MrGeoProperties.resetProperties();
   if (conf != null)
   {
-    oldConfValues = new HashMap<>();
-
-    oldConfValues.put(DataProviderFactory.PREFERRED_ADHOC_PROVIDER_NAME,
-        conf.get(DataProviderFactory.PREFERRED_ADHOC_PROVIDER_NAME, null));
-    oldConfValues.put(DataProviderFactory.PREFERRED_MRSIMAGE_PROVIDER_NAME,
-        conf.get(DataProviderFactory.PREFERRED_MRSIMAGE_PROVIDER_NAME, null));
-    oldConfValues.put(DataProviderFactory.PREFERRED_VECTOR_PROVIDER_NAME,
-        conf.get(DataProviderFactory.PREFERRED_VECTOR_PROVIDER_NAME, null));
+//    oldConfValues = new HashMap<>();
+//
+//    oldConfValues.put(DataProviderFactory.PREFERRED_ADHOC_PROVIDER_NAME,
+//        conf.get(DataProviderFactory.PREFERRED_ADHOC_PROVIDER_NAME, null));
+//    oldConfValues.put(DataProviderFactory.PREFERRED_MRSIMAGE_PROVIDER_NAME,
+//        conf.get(DataProviderFactory.PREFERRED_MRSIMAGE_PROVIDER_NAME, null));
+//    oldConfValues.put(DataProviderFactory.PREFERRED_VECTOR_PROVIDER_NAME,
+//        conf.get(DataProviderFactory.PREFERRED_VECTOR_PROVIDER_NAME, null));
 
     if (confVal == null)
     {
@@ -645,16 +643,16 @@ private void setupPreferred(Configuration conf, String confVal,
 
   Properties mp = MrGeoProperties.getInstance();
 
-  oldMrGeoValues = new HashMap<>();
-
-  oldMrGeoValues.put(DataProviderFactory.PREFERRED_ADHOC_PROPERTYNAME,
-      mp.getProperty(DataProviderFactory.PREFERRED_ADHOC_PROPERTYNAME, null));
-  oldMrGeoValues.put(DataProviderFactory.PREFERRED_MRSIMAGE_PROPERTYNAME,
-      mp.getProperty(DataProviderFactory.PREFERRED_MRSIMAGE_PROPERTYNAME, null));
-  oldMrGeoValues.put(DataProviderFactory.PREFERRED_VECTOR_PROPERTYNAME,
-      mp.getProperty(DataProviderFactory.PREFERRED_VECTOR_PROPERTYNAME, null));
-  oldMrGeoValues.put(DataProviderFactory.PREFERRED_PROPERTYNAME,
-      mp.getProperty(DataProviderFactory.PREFERRED_PROPERTYNAME, null));
+//  oldMrGeoValues = new HashMap<>();
+//
+//  oldMrGeoValues.put(DataProviderFactory.PREFERRED_ADHOC_PROPERTYNAME,
+//      mp.getProperty(DataProviderFactory.PREFERRED_ADHOC_PROPERTYNAME, null));
+//  oldMrGeoValues.put(DataProviderFactory.PREFERRED_MRSIMAGE_PROPERTYNAME,
+//      mp.getProperty(DataProviderFactory.PREFERRED_MRSIMAGE_PROPERTYNAME, null));
+//  oldMrGeoValues.put(DataProviderFactory.PREFERRED_VECTOR_PROPERTYNAME,
+//      mp.getProperty(DataProviderFactory.PREFERRED_VECTOR_PROPERTYNAME, null));
+//  oldMrGeoValues.put(DataProviderFactory.PREFERRED_PROPERTYNAME,
+//      mp.getProperty(DataProviderFactory.PREFERRED_PROPERTYNAME, null));
 
   if (mrgeoVal == null)
   {
@@ -682,36 +680,37 @@ private void setupPreferred(Configuration conf, String confVal,
 
 private void teardownPreferred(Configuration conf)
 {
-  if (conf != null && oldConfValues != null)
-  {
-    for (Map.Entry<String, String> val : oldConfValues.entrySet())
-    {
-      if (val.getValue() == null)
-      {
-        conf.unset(val.getKey());
-      }
-      else
-      {
-        conf.set(val.getKey(), val.getValue());
-      }
-    }
-  }
-
-  if (oldMrGeoValues != null)
-  {
-    Properties mp = MrGeoProperties.getInstance();
-    for (Map.Entry<String, String> val : oldMrGeoValues.entrySet())
-    {
-      if (val.getValue() == null)
-      {
-        mp.remove(val.getKey());
-      }
-      else
-      {
-        mp.setProperty(val.getKey(), val.getValue());
-      }
-    }
-  }
+  MrGeoProperties.resetProperties();
+//  if (conf != null && oldConfValues != null)
+//  {
+//    for (Map.Entry<String, String> val : oldConfValues.entrySet())
+//    {
+//      if (val.getValue() == null)
+//      {
+//        conf.unset(val.getKey());
+//      }
+//      else
+//      {
+//        conf.set(val.getKey(), val.getValue());
+//      }
+//    }
+//  }
+//
+//  if (oldMrGeoValues != null)
+//  {
+//    Properties mp = MrGeoProperties.getInstance();
+//    for (Map.Entry<String, String> val : oldMrGeoValues.entrySet())
+//    {
+//      if (val.getValue() == null)
+//      {
+//        mp.remove(val.getKey());
+//      }
+//      else
+//      {
+//        mp.setProperty(val.getKey(), val.getValue());
+//      }
+//    }
+//  }
 }
 
 }

--- a/mrgeo-core/src/test/java/org/mrgeo/hdfs/image/HdfsMrsImageDataProviderFactoryTest.java
+++ b/mrgeo-core/src/test/java/org/mrgeo/hdfs/image/HdfsMrsImageDataProviderFactoryTest.java
@@ -29,6 +29,7 @@ import org.junit.experimental.categories.Category;
 import org.mrgeo.core.Defs;
 import org.mrgeo.core.MrGeoConstants;
 import org.mrgeo.core.MrGeoProperties;
+import org.mrgeo.core.MrGeoPropertiesTest;
 import org.mrgeo.data.ProviderProperties;
 import org.mrgeo.data.image.MrsImageDataProvider;
 import org.mrgeo.hdfs.utils.HadoopFileUtils;
@@ -51,7 +52,7 @@ private static String all_ones = Defs.INPUT + "all-ones";
 HdfsMrsImageDataProviderFactory factory;
 Configuration conf;
 ProviderProperties providerProperties;
-private String oldImageBase;
+//private String oldImageBase;
 
 @BeforeClass
 static public void setup() throws IOException
@@ -66,7 +67,8 @@ static public void setup() throws IOException
 @Before
 public void init()
 {
-  oldImageBase = MrGeoProperties.getInstance().getProperty(MrGeoConstants.MRGEO_HDFS_IMAGE, "");
+  MrGeoProperties.resetProperties();
+//  oldImageBase = MrGeoProperties.getInstance().getProperty(MrGeoConstants.MRGEO_HDFS_IMAGE, "");
 
   MrGeoProperties.getInstance().setProperty(MrGeoConstants.MRGEO_HDFS_IMAGE, (new File(Defs.INPUT)).toURI().toString());
   factory = new HdfsMrsImageDataProviderFactory();
@@ -78,7 +80,8 @@ public void init()
 @After
 public void teardown()
 {
-  MrGeoProperties.getInstance().setProperty(MrGeoConstants.MRGEO_HDFS_IMAGE, oldImageBase);
+//  MrGeoProperties.getInstance().setProperty(MrGeoConstants.MRGEO_HDFS_IMAGE, oldImageBase);
+  MrGeoProperties.resetProperties();
 }
 
 @Test

--- a/mrgeo-core/src/test/java/org/mrgeo/hdfs/image/HdfsMrsImageDataProviderTest.java
+++ b/mrgeo-core/src/test/java/org/mrgeo/hdfs/image/HdfsMrsImageDataProviderTest.java
@@ -58,6 +58,7 @@ static public void setup() throws IOException
 @Before
 public void init()
 {
+  MrGeoProperties.resetProperties();
   MrGeoProperties.getInstance().setProperty(MrGeoConstants.MRGEO_HDFS_IMAGE, (new File(Defs.INPUT)).toURI().toString());
   provider = new HdfsMrsImageDataProvider(conf, all_ones, null);
 }
@@ -65,6 +66,7 @@ public void init()
 @After
 public void tearDown() throws IOException
 {
+  MrGeoProperties.resetProperties();
 }
 
 @Test

--- a/mrgeo-core/src/test/java/org/mrgeo/publisher/MrGeoPublisherFactoryTest.java
+++ b/mrgeo-core/src/test/java/org/mrgeo/publisher/MrGeoPublisherFactoryTest.java
@@ -5,6 +5,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mrgeo.core.MrGeoProperties;
+import org.mrgeo.core.MrGeoPropertiesTest;
 import org.mrgeo.image.MrsPyramidMetadata;
 import org.mrgeo.junit.UnitTest;
 
@@ -35,6 +36,7 @@ private Properties mrGeoProperties;
 @Before
 public void setUp() throws Exception
 {
+  MrGeoProperties.resetProperties();
   // Get the MrGeoProperties instance.  Because a static reference to the properties returned are held by the
   // MrGeoProperties class, we can inject any properties needed for testing
   mrGeoProperties = MrGeoProperties.getInstance();
@@ -60,7 +62,8 @@ public void setUp() throws Exception
 @After
 public void tearDown() throws Exception
 {
-  mrGeoProperties.clear();
+  MrGeoProperties.resetProperties();
+
   MrGeoPublisherFactory.clearCache();
   MrGeoTestPublisherConfigurator1.clearArguments();
   MrGeoTestPublisherConfigurator2.clearArguments();

--- a/mrgeo-mapalgebra/mrgeo-mapalgebra-integrationtests/src/test/java/org/mrgeo/mapalgebra/MapAlgebraIntegrationTest.java
+++ b/mrgeo-mapalgebra/mrgeo-mapalgebra-integrationtests/src/test/java/org/mrgeo/mapalgebra/MapAlgebraIntegrationTest.java
@@ -19,10 +19,7 @@ package org.mrgeo.mapalgebra;
 import junit.framework.Assert;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.experimental.categories.Category;
 import org.mrgeo.core.Defs;
 import org.mrgeo.core.MrGeoConstants;
@@ -162,6 +159,12 @@ public void setup()
       .setProperty(MrGeoConstants.MRGEO_HDFS_IMAGE, testUtils.getInputHdfs().toUri().toString());
   MrGeoProperties.getInstance()
       .setProperty(MrGeoConstants.MRGEO_HDFS_VECTOR, testUtils.getInputHdfs().toUri().toString());
+}
+
+@After
+public void teardown()
+{
+  MrGeoProperties.resetProperties();
 }
 
 @Test

--- a/mrgeo-services/mrgeo-services-core/src/test/java/org/mrgeo/services/mrspyramid/MrsPyramidServiceTest.java
+++ b/mrgeo-services/mrgeo-services-core/src/test/java/org/mrgeo/services/mrspyramid/MrsPyramidServiceTest.java
@@ -16,6 +16,7 @@
 package org.mrgeo.services.mrspyramid;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -77,6 +78,12 @@ public MrsPyramidServiceTest()
 public void setUp() throws Exception
 {
   testutils = new TestUtils(MrsPyramidServiceTest.class);
+}
+
+@After
+public void teardown()
+{
+  MrGeoProperties.resetProperties();
 }
 
 @Test

--- a/mrgeo-services/mrgeo-services-tms/src/test/java/org/mrgeo/resources/tms/TileMapServiceResourceIntegrationTest.java
+++ b/mrgeo-services/mrgeo-services-tms/src/test/java/org/mrgeo/resources/tms/TileMapServiceResourceIntegrationTest.java
@@ -79,6 +79,7 @@ public void setUp() throws Exception
 {
   super.setUp();
   Mockito.reset(service, request);
+  MrGeoProperties.resetProperties();
   Properties props = MrGeoProperties.getInstance();
   props.put(MrGeoConstants.MRGEO_HDFS_IMAGE, input);
   props.put(MrGeoConstants.MRGEO_HDFS_COLORSCALE, input + "color-scales");
@@ -86,6 +87,12 @@ public void setUp() throws Exception
   baselineInput = TestUtils.composeInputDir(TileMapServiceResourceIntegrationTest.class);
 
   TileMapServiceResource.props = props;
+}
+
+@Override
+public void tearDown() throws Exception {
+  super.tearDown();
+  MrGeoProperties.resetProperties();
 }
 
 @Test

--- a/mrgeo-services/mrgeo-services-wms/src/test/java/org/mrgeo/resources/wms/CustomColorScaleTest.java
+++ b/mrgeo-services/mrgeo-services-wms/src/test/java/org/mrgeo/resources/wms/CustomColorScaleTest.java
@@ -18,6 +18,7 @@ package org.mrgeo.resources.wms;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -55,6 +56,12 @@ public static void setUpForJUnit()
   {
     e.printStackTrace();
   }
+}
+
+@After
+public void teardown()
+{
+  MrGeoProperties.resetProperties();
 }
 
 /*

--- a/mrgeo-services/mrgeo-services-wms/src/test/java/org/mrgeo/resources/wms/DescribeTilesTest.java
+++ b/mrgeo-services/mrgeo-services-wms/src/test/java/org/mrgeo/resources/wms/DescribeTilesTest.java
@@ -16,6 +16,7 @@
 
 package org.mrgeo.resources.wms;
 
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -54,6 +55,12 @@ public static void setUpForJUnit()
   {
     e.printStackTrace();
   }
+}
+
+@AfterClass
+public static void teardownForJUnit()
+{
+  MrGeoProperties.resetProperties();
 }
 
   /*

--- a/mrgeo-services/mrgeo-services-wms/src/test/java/org/mrgeo/resources/wms/WmsGeneratorTestAbstract.java
+++ b/mrgeo-services/mrgeo-services-wms/src/test/java/org/mrgeo/resources/wms/WmsGeneratorTestAbstract.java
@@ -25,11 +25,11 @@ import org.custommonkey.xmlunit.XMLAssert;
 import org.custommonkey.xmlunit.XMLUnit;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.TestName;
-import org.mrgeo.colorscale.ColorScaleManager;
 import org.mrgeo.core.Defs;
 import org.mrgeo.core.MrGeoConstants;
 import org.mrgeo.core.MrGeoProperties;
@@ -102,6 +102,7 @@ public TestName testname = new TestName();
 @BeforeClass
 public static void setUpForJUnit()
 {
+  MrGeoProperties.resetProperties();
   try
   {
     DataProviderFactory.invalidateCache();
@@ -123,6 +124,12 @@ public static void setUpForJUnit()
   {
     e.printStackTrace();
   }
+}
+
+@AfterClass
+public static void teardownForJUnit()
+{
+  MrGeoProperties.resetProperties();
 }
 
 // TODO: all test classes are using the same set of input data for now to make things simpler...

--- a/mrgeo-services/mrgeo-services-wms/testFiles/org.mrgeo.resources.wms/BadRequestTest/wms-invalid-coordsys.xml
+++ b/mrgeo-services/mrgeo-services-wms/testFiles/org.mrgeo.resources.wms/BadRequestTest/wms-invalid-coordsys.xml
@@ -4,7 +4,7 @@
 	at org.mrgeo.resources.wms.WmsGenerator.getMap(WmsGenerator.java:447)
 	at org.mrgeo.resources.wms.WmsGenerator.handleRequest(WmsGenerator.java:300)
 	at org.mrgeo.resources.wms.WmsGenerator.doGet(WmsGenerator.java:160)
-	at sun.reflect.GeneratedMethodAccessor19.invoke(Unknown Source)
+	at sun.reflect.GeneratedMethodAccessor29.invoke(Unknown Source)
 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
 	at java.lang.reflect.Method.invoke(Method.java:498)
 	at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory$1.invoke(ResourceMethodInvocationHandlerFactory.java:81)

--- a/mrgeo-services/mrgeo-services-wms/testFiles/org.mrgeo.resources.wms/GetMapTest/testGetMapInvalidLayer.xml
+++ b/mrgeo-services/mrgeo-services-wms/testFiles/org.mrgeo.resources.wms/GetMapTest/testGetMapInvalidLayer.xml
@@ -4,7 +4,7 @@
 	at org.mrgeo.resources.wms.WmsGenerator.getMap(WmsGenerator.java:447)
 	at org.mrgeo.resources.wms.WmsGenerator.handleRequest(WmsGenerator.java:300)
 	at org.mrgeo.resources.wms.WmsGenerator.doGet(WmsGenerator.java:160)
-	at sun.reflect.GeneratedMethodAccessor19.invoke(Unknown Source)
+	at sun.reflect.GeneratedMethodAccessor29.invoke(Unknown Source)
 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
 	at java.lang.reflect.Method.invoke(Method.java:498)
 	at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory$1.invoke(ResourceMethodInvocationHandlerFactory.java:81)


### PR DESCRIPTION
- A number of tests make changes to the MrGeoProperties and some of
   them don't properly cleanup those changes before other tests run.
   Exposed a MrGeoProperties functions for resetting the properties
   to force them to be reloaded on next access. Updated tests to call
   this reset if they make changes to those properties for testing.
 - Added logging error information to color scales