### PR TITLE
Add POM profile for a Databricks build

### DIFF
--- a/mrgeo-mapalgebra/mrgeo-mapalgebra-image/src/main/scala/org/mrgeo/mapalgebra/KernelMapOp.scala
+++ b/mrgeo-mapalgebra/mrgeo-mapalgebra-image/src/main/scala/org/mrgeo/mapalgebra/KernelMapOp.scala
@@ -272,6 +272,7 @@ class KernelMapOp extends RasterMapOp with Externalizable {
       case KernelMapOp.Laplacian =>
       case _ => throw new ParserException("Bad kernel method: " + method)
     }
+    this.method = method
   }
 
   private[mapalgebra] def this(node:ParserNode, variables:String => Option[ParserNode]) = {

--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,24 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>1.2</version>
+          <executions>
+            <execution>
+              <id>enforce</id>
+              <configuration>
+                <rules>
+                  <DependencyConvergence/>
+                </rules>
+              </configuration>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
           <artifactId>maven-jar-plugin</artifactId>
           <version>${maven-jar.version}</version>
           <configuration>
@@ -2214,6 +2232,12 @@
           <scope>${hadoop.scope}</scope>
         </dependency>
       </dependencies>
+    </profile>
+    <profile>
+      <id>databricks</id>
+      <properties>
+        <spark.scope>provided</spark.scope>
+      </properties>
     </profile>
     <profile>
       <id>standalone-webserver</id>


### PR DESCRIPTION
- specify Spark as a provided dependency rather than compiled
 - fixed a bug in the python interface for the kernel map op
 - closes #433