### PR TITLE
Add a check for a GDAL error when writing a temporary image

### DIFF
--- a/mrgeo-core/src/main/scala/org/mrgeo/utils/GDALUtils.scala
+++ b/mrgeo-core/src/main/scala/org/mrgeo/utils/GDALUtils.scala
@@ -750,6 +750,11 @@ object GDALUtils extends Logging {
     }
 
     val copy:Dataset = driver.CreateCopy(file, ds, 1, moreoptions)
+    if (copy == null) {
+      val msg = "Unable to create raster " + file + ". Error message from GDAL is: " + gdal.GetLastErrorMsg()
+      log.error(msg)
+      throw new IOException(msg)
+    }
 
     // add the bounds, if sent in.  Reproject if needed
     val xform:Array[Double] = new Array[Double](6)

--- a/mrgeo-mapalgebra/mrgeo-mapalgebra-image/src/main/scala/org/mrgeo/mapalgebra/ZoomMapOp.scala
+++ b/mrgeo-mapalgebra/mrgeo-mapalgebra-image/src/main/scala/org/mrgeo/mapalgebra/ZoomMapOp.scala
@@ -29,8 +29,8 @@ object ZoomMapOp extends MapOpRegistrar {
     Array[String]("zoom")
   }
 
-  def create(raster:RasterMapOp, band:Int = 1) =
-    new ZoomMapOp(Some(raster), band)
+  def create(raster:RasterMapOp, zoom:Int = 1) =
+    new ZoomMapOp(Some(raster), zoom)
 
   override def apply(node:ParserNode, variables:String => Option[ParserNode]):MapOp =
     new ZoomMapOp(node, variables)


### PR DESCRIPTION
- also change the parameter name for the zoom map op