### PR TITLE
Add new export option to set maximum output image size

### DIFF
--- a/mrgeo-cmd/mrgeo-cmd-export/src/main/java/org/mrgeo/cmd/export/Export.java
+++ b/mrgeo-cmd/mrgeo-cmd-export/src/main/java/org/mrgeo/cmd/export/Export.java
@@ -33,15 +33,13 @@ import org.mrgeo.data.DataProviderFactory;
 import org.mrgeo.data.ProviderProperties;
 import org.mrgeo.data.image.MrsImageDataProvider;
 import org.mrgeo.data.raster.MrGeoRaster;
+import org.mrgeo.data.raster.RasterUtils;
 import org.mrgeo.data.tile.TileNotFoundException;
 import org.mrgeo.image.MrsImage;
 import org.mrgeo.image.MrsImageException;
 import org.mrgeo.image.MrsPyramid;
 import org.mrgeo.image.MrsPyramidMetadata;
-import org.mrgeo.utils.FileUtils;
-import org.mrgeo.utils.GDALJavaUtils;
-import org.mrgeo.utils.HadoopUtils;
-import org.mrgeo.utils.LongRectangle;
+import org.mrgeo.utils.*;
 import org.mrgeo.utils.logging.LoggingUtils;
 import org.mrgeo.utils.tms.Bounds;
 import org.mrgeo.utils.tms.TMSUtils;
@@ -73,6 +71,7 @@ private boolean useBounds = false;
 private Set<Long> tileset = null;
 private ColorScale colorscale = null;
 private boolean useTMS;
+private int maxSizeInKb = -1;
 
 @Override
 @SuppressWarnings("squid:S1166") // Exception caught and handled
@@ -137,6 +136,11 @@ public int run(CommandLine line, Configuration conf,
       colorscale = ColorScaleManager.fromName(line.getOptionValue("cs"));
     }
 
+    if (line.hasOption("ms"))
+    {
+      maxSizeInKb = SparkUtils.humantokb(line.getOptionValue("ms"));
+    }
+
     boolean useTileSet = line.hasOption("t");
     if (useTileSet)
     {
@@ -168,9 +172,11 @@ public int run(CommandLine line, Configuration conf,
 //        FileUtils.createDir(new File(outputbase));
 //      }
 
+    if (maxSizeInKb > 0 && !singleImage) {
+      throw new ParseException("maxsize can only be specified along with single");
+    }
     for (final String arg : line.getArgs())
     {
-      // The input can be either an image or a vector.
       MrsPyramid imagePyramid;
       MrsPyramid pyramid = null;
       String pyramidName = "";
@@ -189,9 +195,39 @@ public int run(CommandLine line, Configuration conf,
 
       if (imagePyramid == null)
       {
-        throw new ParseException("Specified input must be either an image or a vector");
+        throw new ParseException("Specified input must be an image");
       }
-      if (zoomlevel <= 0)
+
+      MrsPyramidMetadata meta = pyramid.getMetadata();
+      ColorScaleApplier applier = null;
+      if (colorscale != null || !"tif".equalsIgnoreCase(format)) {
+        switch (format) {
+          case "jpg":
+          case "jpeg":
+            applier = new JpegColorScaleApplier();
+            break;
+          case "tif":
+          case "png":
+          default:
+            applier = new PngColorScaleApplier();
+            break;
+        }
+      }
+
+      if (maxSizeInKb > 0) {
+        // Compute the zoom level required to keep the output image smaller
+        // than the specified max size.
+        MrGeoRaster raster = pyramid.getHighestResImage().getRaster();
+        int bytesPerPixelPerBand = (applier != null) ? applier.getBytesPerPixelPerBand() : raster.bytesPerPixel();
+        int bands = (applier != null) ? applier.getBands(raster) : 1;
+        Bounds b = (useBounds) ? bounds : pyramid.getBounds();
+        int maxZoom = pyramid.getMaximumLevel();
+        zoomlevel = RasterUtils.getMaxPixelsForSize(maxSizeInKb, b,
+                bytesPerPixelPerBand, bands, meta.getTilesize()).getZoom();
+        zoomlevel = Math.min(zoomlevel, maxZoom);
+        System.out.println("Exporting image at zoom level " + zoomlevel);
+      }
+      else if (zoomlevel <= 0)
       {
         zoomlevel = pyramid.getMaximumLevel();
       }
@@ -240,8 +276,9 @@ public int run(CommandLine line, Configuration conf,
             {
               ob += "-" + zoomlevel;
             }
-            saveMultipleTiles(ob, pyramidName, format,
-                image, ArrayUtils.toPrimitive(tiles.toArray(new Long[tiles.size()])), providerProperties);
+            saveMultipleTiles(ob, pyramidName, format, image, applier,
+                    ArrayUtils.toPrimitive(tiles.toArray(new Long[tiles.size()])),
+                    providerProperties);
           }
           else if (mosaicTiles && mosaicTileCount > 0)
           {
@@ -267,15 +304,17 @@ public int run(CommandLine line, Configuration conf,
               }
 //                final String mosaicOutput = output + "/" + t.ty + "-" + t.tx + "-" +
 //                    TMSUtils.tileid(t.tx, t.ty, zoomlevel);
-              saveMultipleTiles(outputbase, pyramidName, format, image,
-                  ArrayUtils.toPrimitive(tilesToMosaic.toArray(new Long[tilesToMosaic.size()])), providerProperties);
+              saveMultipleTiles(outputbase, pyramidName, format, image, applier,
+                      ArrayUtils.toPrimitive(tilesToMosaic.toArray(new Long[tilesToMosaic.size()])),
+                      providerProperties);
             }
           }
           else
           {
             for (final Long tileid : tiles)
             {
-              saveSingleTile(outputbase, pyramidName, image, format, tileid, zoomlevel, tilesize, providerProperties);
+              saveSingleTile(outputbase, pyramidName, image, applier, format,
+                      tileid, zoomlevel, tilesize, providerProperties);
             }
           }
         }
@@ -343,6 +382,10 @@ public void addOptions(Options options)
   color.setRequired(false);
   options.addOption(color);
 
+  final Option maxImageSize = new Option("ms", "maxsize", true, "Maximum size of output image (in kb)");
+  maxImageSize.setRequired(false);
+  options.addOption(maxImageSize);
+
   final Option tileIds = new Option("t", "tileids", true,
       "A comma separated list of tile ID's to export");
   tileIds.setRequired(false);
@@ -386,8 +429,61 @@ private Bounds parseBounds(String boundsOption)
   return new Bounds(w, s, e, n);
 }
 
+private MrGeoRaster colorRaster(MrGeoRaster raster,
+                                MrsPyramidMetadata metadata,
+                                ColorScaleApplier applier,
+                                final int zoom,
+                                final String pyramidName,
+                                final String format,
+                                final ProviderProperties providerProperties) throws IOException
+{
+  if (colorscale != null || !"tif".equals(format))
+  {
+    if (colorscale == null) {
+      MrsImageDataProvider dp = DataProviderFactory.getMrsImageDataProvider(pyramidName,
+              DataProviderFactory.AccessMode.READ, providerProperties);
+      MrsPyramidMetadata meta = dp.getMetadataReader().read();
+
+      String csname = meta.getTag(MrGeoConstants.MRGEO_DEFAULT_COLORSCALE);
+      if (csname != null)
+      {
+        try
+        {
+          colorscale = ColorScaleManager.fromName(csname);
+        }
+        catch (ColorScale.ColorScaleException ignored)
+        {
+        }
+        if (colorscale == null)
+        {
+          throw new IOException("Can not load default style: "  + csname);
+        }
+      }
+      else
+      {
+        colorscale = ColorScale.createDefaultGrayScale();
+      }
+
+    }
+    try
+    {
+      raster = applier.applyColorScale(raster,
+              colorscale,
+              metadata.getExtrema(zoom),
+              metadata.getDefaultValues(),
+              metadata.getQuantiles());
+    }
+    catch (Exception e)
+    {
+      log.error("Exception thrown", e);
+    }
+  }
+  return raster;
+}
+
 private boolean saveSingleTile(final String output, final String pyramidName, final MrsImage image,
-    String format, final long tileid, final int zoom, int tilesize, ProviderProperties providerProperties)
+    ColorScaleApplier applier, String format, final long tileid,
+    final int zoom, int tilesize, ProviderProperties providerProperties)
 {
   try
   {
@@ -403,37 +499,7 @@ private boolean saveSingleTile(final String output, final String pyramidName, fi
     {
       String out = makeOutputName(output, pyramidName, format, tileid, zoom, tilesize, true);
 
-      if (colorscale != null || !format.equals("tif"))
-      {
-        if (colorscale == null) {
-          MrsImageDataProvider dp = DataProviderFactory.getMrsImageDataProvider(pyramidName,
-              DataProviderFactory.AccessMode.READ, providerProperties);
-          MrsPyramidMetadata meta = dp.getMetadataReader().read();
-
-          String csname = meta.getTag(MrGeoConstants.MRGEO_DEFAULT_COLORSCALE);
-          if (csname != null)
-          {
-            try
-            {
-              colorscale = ColorScaleManager.fromName(csname);
-            }
-            catch (ColorScale.ColorScaleException ignored)
-            {
-            }
-            if (colorscale == null)
-            {
-              throw new IOException("Can not load default style: "  + csname);
-            }
-          }
-          else
-          {
-            colorscale = ColorScale.createDefaultGrayScale();
-          }
-
-        }
-        raster = colorRaster(image, format, raster);
-      }
-
+      raster = colorRaster(raster, metadata, applier, zoom, pyramidName, format, providerProperties);
       Bounds bnds = TMSUtils.tileBounds(t.tx, t.ty, image.getZoomlevel(), metadata.getTilesize());
       GDALJavaUtils.saveRasterTile(raster.toDataset(bnds, metadata.getDefaultValues()),
           out, t.tx, t.ty, image.getZoomlevel(), metadata.getDefaultValue(0), format);
@@ -455,37 +521,10 @@ private boolean saveSingleTile(final String output, final String pyramidName, fi
   return false;
 }
 
-private MrGeoRaster colorRaster(MrsImage image, String format, MrGeoRaster raster)
-{
-  final ColorScaleApplier applier;
-  switch (format)
-  {
-  case "jpg":
-  case "jpeg":
-    applier = new JpegColorScaleApplier();
-    break;
-  case "tif":
-  case "png":
-  default:
-    applier = new PngColorScaleApplier();
-    break;
-  }
-
-  try
-  {
-    raster = applier.applyColorScale(raster, colorscale, image.getExtrema(),
-            image.getMetadata().getDefaultValues(), image.getMetadata().getQuantiles());
-  }
-  catch (Exception e)
-  {
-    log.error("Exception thrown", e);
-  }
-
-  return raster;
-}
-
-private boolean saveMultipleTiles(String output, String pyramidName, String format,
-    final MrsImage image, final long[] tiles, ProviderProperties providerProperties)
+private boolean saveMultipleTiles(String output, String pyramidName,
+                                  String format, final MrsImage image,
+                                  ColorScaleApplier applier,
+                                  final long[] tiles, ProviderProperties providerProperties)
 {
   try
   {
@@ -534,39 +573,7 @@ private boolean saveMultipleTiles(String output, String pyramidName, String form
       throw new MrsImageException("Error, could not load any tiles");
     }
     String out = makeOutputName(output, pyramidName, format, minId, zoomlevel, tilesize, false);
-
-    if (colorscale != null || !format.equals("tif"))
-    {
-      if (colorscale == null) {
-        MrsImageDataProvider dp = DataProviderFactory.getMrsImageDataProvider(pyramidName,
-            DataProviderFactory.AccessMode.READ, providerProperties);
-        MrsPyramidMetadata meta = dp.getMetadataReader().read();
-
-        String csname = meta.getTag(MrGeoConstants.MRGEO_DEFAULT_COLORSCALE);
-        if (csname != null)
-        {
-          try
-          {
-            colorscale = ColorScaleManager.fromName(csname);
-          }
-          catch (ColorScale.ColorScaleException ignored)
-          {
-          }
-          if (colorscale == null)
-          {
-            throw new IOException("Can not load default style: "  + csname);
-          }
-        }
-        else
-        {
-          colorscale = ColorScale.createDefaultGrayScale();
-        }
-
-      }
-
-      raster = colorRaster(image, format, raster);
-    }
-
+    raster = colorRaster(raster, metadata, applier, zoomlevel, pyramidName, format, providerProperties);
     GDALJavaUtils
         .saveRaster(raster.toDataset(imageBounds, metadata.getDefaultValues()), out, null, metadata.getDefaultValue(0),
             format);

--- a/mrgeo-core/src/main/java/org/mrgeo/colorscale/applier/ColorScaleApplier.java
+++ b/mrgeo-core/src/main/java/org/mrgeo/colorscale/applier/ColorScaleApplier.java
@@ -40,6 +40,10 @@ public abstract String[] getMimeTypes();
 
 public abstract String[] getWmsFormats();
 
+public abstract int getBytesPerPixelPerBand();
+
+public abstract int getBands(final MrGeoRaster raster);
+
 protected void apply(final MrGeoRaster source, final MrGeoRaster dest, ColorScale colorScale)
 {
   if (source.bands() == dest.bands() && (source.bands() == 3 || source.bands() == 4))

--- a/mrgeo-core/src/main/java/org/mrgeo/colorscale/applier/JpegColorScaleApplier.java
+++ b/mrgeo-core/src/main/java/org/mrgeo/colorscale/applier/JpegColorScaleApplier.java
@@ -37,7 +37,7 @@ public MrGeoRaster applyColorScale(final MrGeoRaster raster, ColorScale colorSca
 {
   try
   {
-    MrGeoRaster colored = MrGeoRaster.createEmptyRaster(raster.width(), raster.height(), 3, DataBuffer.TYPE_BYTE);
+    MrGeoRaster colored = MrGeoRaster.createEmptyRaster(raster.width(), raster.height(), getBands(raster), DataBuffer.TYPE_BYTE);
     colored.fill(RasterUtils.getDefaultNoDataForType(DataBuffer.TYPE_BYTE));
 
     setupExtrema(colorScale, extrema, defaultValues[0],
@@ -50,6 +50,18 @@ public MrGeoRaster applyColorScale(final MrGeoRaster raster, ColorScale colorSca
     throw new ColorScale.ColorScaleException(e);
   }
 
+}
+
+@Override
+public int getBytesPerPixelPerBand()
+{
+  return 1;
+}
+
+@Override
+public int getBands(final MrGeoRaster raster)
+{
+  return 3;
 }
 
 @Override

--- a/mrgeo-core/src/main/java/org/mrgeo/colorscale/applier/PngColorScaleApplier.java
+++ b/mrgeo-core/src/main/java/org/mrgeo/colorscale/applier/PngColorScaleApplier.java
@@ -44,7 +44,7 @@ public MrGeoRaster applyColorScale(final MrGeoRaster raster, ColorScale colorSca
   try
   {
     MrGeoRaster colored = MrGeoRaster
-        .createEmptyRaster(raster.width(), raster.height(), raster.bands() == 3 ? 3 : 4, DataBuffer.TYPE_BYTE);
+        .createEmptyRaster(raster.width(), raster.height(), getBands(raster), DataBuffer.TYPE_BYTE);
     colored.fill(RasterUtils.getDefaultNoDataForType(DataBuffer.TYPE_BYTE));
 
     setupExtrema(colorScale, extrema, defaultValues[0],
@@ -56,6 +56,18 @@ public MrGeoRaster applyColorScale(final MrGeoRaster raster, ColorScale colorSca
   {
     throw new ColorScale.ColorScaleException(e);
   }
+}
+
+@Override
+public int getBytesPerPixelPerBand()
+{
+  return 1;
+}
+
+@Override
+public int getBands(final MrGeoRaster raster)
+{
+  return raster.bands() == 3 ? 3 : 4;
 }
 
 @Override

--- a/mrgeo-core/src/main/java/org/mrgeo/data/raster/MrGeoByteRaster.java
+++ b/mrgeo-core/src/main/java/org/mrgeo/data/raster/MrGeoByteRaster.java
@@ -114,7 +114,7 @@ public void setPixel(int x, int y, int band, double pixel)
 }
 
 @Override
-int bytesPerPixel()
+public int bytesPerPixel()
 {
   return BYTES_PER_PIXEL;
 }

--- a/mrgeo-core/src/main/java/org/mrgeo/data/raster/MrGeoDoubleRaster.java
+++ b/mrgeo-core/src/main/java/org/mrgeo/data/raster/MrGeoDoubleRaster.java
@@ -114,7 +114,7 @@ public void setPixel(int x, int y, int band, double pixel)
 }
 
 @Override
-int bytesPerPixel()
+public int bytesPerPixel()
 {
   return BYTES_PER_PIXEL;
 }

--- a/mrgeo-core/src/main/java/org/mrgeo/data/raster/MrGeoFloatRaster.java
+++ b/mrgeo-core/src/main/java/org/mrgeo/data/raster/MrGeoFloatRaster.java
@@ -114,7 +114,7 @@ public void setPixel(int x, int y, int band, double pixel)
 }
 
 @Override
-int bytesPerPixel()
+public int bytesPerPixel()
 {
   return BYTES_PER_PIXEL;
 }

--- a/mrgeo-core/src/main/java/org/mrgeo/data/raster/MrGeoIntRaster.java
+++ b/mrgeo-core/src/main/java/org/mrgeo/data/raster/MrGeoIntRaster.java
@@ -114,7 +114,7 @@ public void setPixel(int x, int y, int band, double pixel)
 }
 
 @Override
-int bytesPerPixel()
+public int bytesPerPixel()
 {
   return BYTES_PER_PIXEL;
 }

--- a/mrgeo-core/src/main/java/org/mrgeo/data/raster/MrGeoRaster.java
+++ b/mrgeo-core/src/main/java/org/mrgeo/data/raster/MrGeoRaster.java
@@ -1004,7 +1004,7 @@ final int[] calculateByteRangeOffset(final int startx, final int starty, final i
       ((endy * width + endx) + (endband * bandoffset)) * bpp + dataoffset};
 }
 
-abstract int bytesPerPixel();
+public abstract int bytesPerPixel();
 
 public static class MrGeoRasterException extends IOException
 {

--- a/mrgeo-core/src/main/java/org/mrgeo/data/raster/MrGeoShortRaster.java
+++ b/mrgeo-core/src/main/java/org/mrgeo/data/raster/MrGeoShortRaster.java
@@ -114,7 +114,7 @@ public void setPixel(int x, int y, int band, double pixel)
 }
 
 @Override
-int bytesPerPixel()
+public int bytesPerPixel()
 {
   return BYTES_PER_PIXEL;
 }

--- a/mrgeo-core/src/main/java/org/mrgeo/data/raster/MrGeoUShortRaster.java
+++ b/mrgeo-core/src/main/java/org/mrgeo/data/raster/MrGeoUShortRaster.java
@@ -114,7 +114,7 @@ public void setPixel(int x, int y, int band, double pixel)
 }
 
 @Override
-int bytesPerPixel()
+public int bytesPerPixel()
 {
   return BYTES_PER_PIXEL;
 }

--- a/mrgeo-core/src/main/java/org/mrgeo/image/MrsPyramid.java
+++ b/mrgeo-core/src/main/java/org/mrgeo/image/MrsPyramid.java
@@ -283,13 +283,20 @@ public MrsImage getHighestResImage() throws IOException
 @SuppressFBWarnings(value = "BC_UNCONFIRMED_CAST_OF_RETURN_VALUE", justification = "We _are_ checking!")
 public MrsImage getImage(final int level) throws IOException
 {
-  try
-  {
+  try {
     Optional<MrsImage> o = imageCache.get(level);
 
     //      System.out.println("get image: " + metadata.getPyramid() + "/" + level +
     //        " (" + (o.isPresent() ? "found" : "null") + ")");
-    return o.isPresent() ? o.get() : null;
+    if (o.isPresent()) {
+      return o.get();
+    }
+    else if (level <= getMaximumLevel()) {
+      return null;
+    }
+    else {
+      throw new IOException("Requested zoom level " + level + " is greater than the max zoom level for the image " + getMaximumLevel());
+    }
   }
   catch (final ExecutionException e)
   {

--- a/mrgeo-core/src/main/java/org/mrgeo/image/MrsPyramidMetadata.java
+++ b/mrgeo-core/src/main/java/org/mrgeo/image/MrsPyramidMetadata.java
@@ -814,13 +814,8 @@ public LongRectangle getOrCreateTileBounds(final int zoomlevel)
     return imageData[zoomlevel].tileBounds;
   }
 
-  LongRectangle tilebounds = getTileBounds(zoomlevel);
-  if (tilebounds == null)
-  {
-    TileBounds tb = TMSUtils.boundsToTile(bounds, zoomlevel, tilesize);
-    tilebounds = new LongRectangle(tb.w, tb.s, tb.e, tb.n);
-  }
-  return tilebounds;
+  TileBounds tb = TMSUtils.boundsToTile(bounds, zoomlevel, tilesize);
+  return new LongRectangle(tb.w, tb.s, tb.e, tb.n);
 }
 
 public LongRectangle getOrCreatePixelBounds(final int zoomlevel)

--- a/mrgeo-mapalgebra/mrgeo-mapalgebra-image/src/test/java/org/mrgeo/mapalgebra/ExportMapOpTest.java
+++ b/mrgeo-mapalgebra/mrgeo-mapalgebra-image/src/test/java/org/mrgeo/mapalgebra/ExportMapOpTest.java
@@ -74,7 +74,7 @@ public void exportOneTile() throws IOException
 //    bounds:String = "", allLevels:Boolean = false, overridenodata:Double = Double.NegativeInfinity):MapOp = {
 
   MapOp exportmapop = ExportMapOp.create(mapop, output,
-      false, -1, -1, -1, "tif", false, false, "", "", "", false,
+      false, -1, "", -1, -1, "tif", false, false, "", "", "", false,
       Double.NEGATIVE_INFINITY);  // this line is all defaults.
 
   exportmapop.execute(localContext);


### PR DESCRIPTION
- add new argument to export command and export map algebra function
   and python API to specify the max size of the exported image. The
   code computes an appropriate zoom level. This is useful for displaying
   map algebra results in a folium map from a local file.
 - Update the export map algebra function to make use of the colorscale
   argument (the same way the command line export does).
 - closes #480
 - closes #430
 - fix a couple of bugs that occur when a zoom level higher than the
   max zoom level for an image is requested when calling MrsPyramid.getImage
   and MrsPyramidMetadata.getOrCreateTileBounds.