### PR TITLE
Fix a bug that causes out of memory during export

### DIFF
--- a/mrgeo-cmd/mrgeo-cmd-export/src/main/java/org/mrgeo/cmd/export/Export.java
+++ b/mrgeo-cmd/mrgeo-cmd-export/src/main/java/org/mrgeo/cmd/export/Export.java
@@ -217,9 +217,9 @@ public int run(CommandLine line, Configuration conf,
       if (maxSizeInKb > 0) {
         // Compute the zoom level required to keep the output image smaller
         // than the specified max size.
-        MrGeoRaster raster = pyramid.getHighestResImage().getRaster();
-        int bytesPerPixelPerBand = (applier != null) ? applier.getBytesPerPixelPerBand() : raster.bytesPerPixel();
-        int bands = (applier != null) ? applier.getBands(raster) : 1;
+        MrGeoRaster rasterForAnyTile = pyramid.getHighestResImage().getAnyTile();
+        int bytesPerPixelPerBand = (applier != null) ? applier.getBytesPerPixelPerBand() : rasterForAnyTile.bytesPerPixel();
+        int bands = (applier != null) ? applier.getBands(pyramid.getMetadata().getBands()) : 1;
         Bounds b = (useBounds) ? bounds : pyramid.getBounds();
         int maxZoom = pyramid.getMaximumLevel();
         zoomlevel = RasterUtils.getMaxPixelsForSize(maxSizeInKb, b,
@@ -346,6 +346,10 @@ public String getUsage() { return "export <options> <input>"; }
 @Override
 public void addOptions(Options options)
 {
+  final Option maxImageSize = new Option("ms", "maxsize", true, "Maximum size of output image (in kb)");
+  maxImageSize.setRequired(false);
+  options.addOption(maxImageSize);
+
   final Option output = new Option("o", "output", true, "Output directory");
   output.setRequired(true);
   options.addOption(output);
@@ -381,10 +385,6 @@ public void addOptions(Options options)
   final Option color = new Option("cs", "colorscale", true, "Color scale to apply");
   color.setRequired(false);
   options.addOption(color);
-
-  final Option maxImageSize = new Option("ms", "maxsize", true, "Maximum size of output image (in kb)");
-  maxImageSize.setRequired(false);
-  options.addOption(maxImageSize);
 
   final Option tileIds = new Option("t", "tileids", true,
       "A comma separated list of tile ID's to export");

--- a/mrgeo-core/src/main/java/org/mrgeo/colorscale/ColorScaleManager.java
+++ b/mrgeo-core/src/main/java/org/mrgeo/colorscale/ColorScaleManager.java
@@ -46,6 +46,7 @@ static
   }
   catch (ColorScale.ColorScaleException e)
   {
+    log.error("Unable to initialize color scales", e);
     throw new RuntimeException("Error initializing ColorScaleManager", e);
   }
 }

--- a/mrgeo-core/src/main/java/org/mrgeo/colorscale/applier/ColorScaleApplier.java
+++ b/mrgeo-core/src/main/java/org/mrgeo/colorscale/applier/ColorScaleApplier.java
@@ -42,7 +42,7 @@ public abstract String[] getWmsFormats();
 
 public abstract int getBytesPerPixelPerBand();
 
-public abstract int getBands(final MrGeoRaster raster);
+public abstract int getBands(final int sourceBands);
 
 protected void apply(final MrGeoRaster source, final MrGeoRaster dest, ColorScale colorScale)
 {

--- a/mrgeo-core/src/main/java/org/mrgeo/colorscale/applier/JpegColorScaleApplier.java
+++ b/mrgeo-core/src/main/java/org/mrgeo/colorscale/applier/JpegColorScaleApplier.java
@@ -37,7 +37,7 @@ public MrGeoRaster applyColorScale(final MrGeoRaster raster, ColorScale colorSca
 {
   try
   {
-    MrGeoRaster colored = MrGeoRaster.createEmptyRaster(raster.width(), raster.height(), getBands(raster), DataBuffer.TYPE_BYTE);
+    MrGeoRaster colored = MrGeoRaster.createEmptyRaster(raster.width(), raster.height(), getBands(raster.bands()), DataBuffer.TYPE_BYTE);
     colored.fill(RasterUtils.getDefaultNoDataForType(DataBuffer.TYPE_BYTE));
 
     setupExtrema(colorScale, extrema, defaultValues[0],
@@ -59,7 +59,7 @@ public int getBytesPerPixelPerBand()
 }
 
 @Override
-public int getBands(final MrGeoRaster raster)
+public int getBands(final int sourceBands)
 {
   return 3;
 }

--- a/mrgeo-core/src/main/java/org/mrgeo/colorscale/applier/PngColorScaleApplier.java
+++ b/mrgeo-core/src/main/java/org/mrgeo/colorscale/applier/PngColorScaleApplier.java
@@ -44,7 +44,7 @@ public MrGeoRaster applyColorScale(final MrGeoRaster raster, ColorScale colorSca
   try
   {
     MrGeoRaster colored = MrGeoRaster
-        .createEmptyRaster(raster.width(), raster.height(), getBands(raster), DataBuffer.TYPE_BYTE);
+        .createEmptyRaster(raster.width(), raster.height(), getBands(raster.bands()), DataBuffer.TYPE_BYTE);
     colored.fill(RasterUtils.getDefaultNoDataForType(DataBuffer.TYPE_BYTE));
 
     setupExtrema(colorScale, extrema, defaultValues[0],
@@ -65,9 +65,9 @@ public int getBytesPerPixelPerBand()
 }
 
 @Override
-public int getBands(final MrGeoRaster raster)
+public int getBands(final int sourceBands)
 {
-  return raster.bands() == 3 ? 3 : 4;
+  return sourceBands == 3 ? 3 : 4;
 }
 
 @Override

--- a/mrgeo-mapalgebra/mrgeo-mapalgebra-image/src/main/scala/org/mrgeo/mapalgebra/ExportMapOp.scala
+++ b/mrgeo-mapalgebra/mrgeo-mapalgebra-image/src/main/scala/org/mrgeo/mapalgebra/ExportMapOp.scala
@@ -210,7 +210,7 @@ class ExportMapOp extends RasterMapOp with Logging with Externalizable {
         }
         val (bytesPerPixelPerBand, bands) = applier match {
           case Some(a) => {
-            (a.getBytesPerPixelPerBand(), a.getBands(raster.get.toRaster()))
+            (a.getBytesPerPixelPerBand(), a.getBands(meta.getBands))
           }
           case None => (raster.get.toRaster().bytesPerPixel(), 1)
         }


### PR DESCRIPTION
- fixed a bug in the export command so it properly recognizes the -ms option
 - also add a log message to color scale manager to help when problems
   occur during the static initialization within the class (e.g. when
   there are problems with color scale definitions)